### PR TITLE
BL-737 Setting Cursor Visibility bug fix

### DIFF
--- a/TouchFree/Assets/TouchFree/Scripts/Cursors/CursorManager.cs
+++ b/TouchFree/Assets/TouchFree/Scripts/Cursors/CursorManager.cs
@@ -87,7 +87,10 @@ public class CursorManager : MonoBehaviour
 
     public void SetCursorVisibility(bool _setTo)
     {
-        currentCursor.SetActive(_setTo);
+        if (currentCursor != null)
+        {
+            currentCursor.SetActive(_setTo);
+        }
     }
 
     [System.Serializable]


### PR DESCRIPTION
Fixed an issue where setting cursor visibility errors SetCursorVisibility is called before the execution order is managed