### PR TITLE
TF-133 Service generates empty App config if one does not exist

### DIFF
--- a/TF_Service_and_Tooling_Unity/Assets/TouchFree/Service/Scripts/ServiceConfigHandler.cs
+++ b/TF_Service_and_Tooling_Unity/Assets/TouchFree/Service/Scripts/ServiceConfigHandler.cs
@@ -1,13 +1,18 @@
 ﻿using UnityEngine;
+using System.IO;
 using Ultraleap.TouchFree.ServiceShared;
 
 namespace Ultraleap.TouchFree.Service
 {
     public class ServiceConfigHandler : MonoBehaviour
     {
+        const string TOUCHFREE_APP_CONFIG_NAME = "TouchFreeConfig.json";
+
         void Start()
         {
             ClientConnectionManager.Instance.LostAllConnections += OnLostAllConnections;
+
+            HandleTFAppConfigSetup();
         }
 
         private void OnDestroy()
@@ -20,6 +25,21 @@ namespace Ultraleap.TouchFree.Service
             ConfigManager.LoadConfigsFromFiles();
             ConfigManager.InteractionConfig.ConfigWasUpdated();
             ConfigManager.PhysicalConfig.ConfigWasUpdated();
+        }
+
+        void HandleTFAppConfigSetup()
+        {
+            if(!Directory.Exists(ConfigFileUtils.ConfigFileDirectory))
+            {
+                Directory.CreateDirectory(ConfigFileUtils.ConfigFileDirectory);
+            }
+
+            string filePath = Path.Combine(ConfigFileUtils.ConfigFileDirectory, TOUCHFREE_APP_CONFIG_NAME);
+
+            if(!File.Exists(filePath))
+            {
+                File.WriteAllText(filePath, "{}");
+            }
         }
     }
 }


### PR DESCRIPTION
TouchFree Service will create an empty TouchFreeApp config file if one does not already exist

- [x] Code Review
- [x] Developer Testing: Key item tests
- [ ] Product Owner Review (Optional)