### PR TITLE
TF-102: Minor Patch to mark pointerevents as coming from a primary pointer

### DIFF
--- a/TF_Tooling_Web/src/InputControllers/WebInputController.ts
+++ b/TF_Tooling_Web/src/InputControllers/WebInputController.ts
@@ -36,6 +36,7 @@ export class WebInputController extends BaseInputController {
         this.baseEventProps = {
             pointerId: this.pointerId,
             bubbles: true,
+            isPrimary: true,
             width: 10,
             height: 10,
             clientX: 0,


### PR DESCRIPTION
This was breaking the ability to utilise OpenLayer's map as it was disregarding all events as coming from a secondary / tertiary etc. pointer and thus was only being thought of as useful for Zooms.