### PR TITLE
TF-177 "Reset to Defaults" button leaves the cursor color selector controls visible

### DIFF
--- a/TF_Application/Assets/TouchFree_Application/Scripts/UI/ConfigUI.cs
+++ b/TF_Application/Assets/TouchFree_Application/Scripts/UI/ConfigUI.cs
@@ -372,7 +372,6 @@ namespace Ultraleap.TouchFree
             SetPresetTogglesBasedOnColors(ConfigManager.Config.activeCursorPreset);
             SetColorsToCorrectPreset();
             UpdatePreviewCursorColors();
-            SetCustomColorControlVisibility(false);
 
             // CTI settings
             EnableCTIToggle.SetIsOnWithoutNotify(ConfigManager.Config.ctiEnabled);
@@ -381,6 +380,8 @@ namespace Ultraleap.TouchFree
 
             ShowHideCursorControls(ConfigManager.Config.cursorEnabled);
             ShowHideCtiControls(ConfigManager.Config.ctiEnabled);
+
+            SetCustomColorControlVisibility(CustomColorPresetToggle.isOn);
 
             switch (ConfigManager.Config.ctiHideTrigger)
             {


### PR DESCRIPTION
force the show/hide of custom cursor settings after the loading of values into the UI

- [ ] Code Review
- [ ] Developer Testing: Key item tests
- [ ] Product Owner Review (Optional)