### PR TITLE
TF-195 CTI video resolution not always the correct resolution

### DIFF
--- a/TF_Application/Assets/TouchFree_Application/Scripts/CallToInteract/CallToInteractController.cs
+++ b/TF_Application/Assets/TouchFree_Application/Scripts/CallToInteract/CallToInteractController.cs
@@ -287,7 +287,7 @@ public class CallToInteractController : MonoBehaviour
             ReleaseRenderTexture();
         }
 
-        videoRenderTexture = new RenderTexture(Screen.width, Screen.height, 0, RenderTextureFormat.ARGB32, 0);
+        videoRenderTexture = new RenderTexture(Display.main.systemWidth, Display.main.systemHeight, 0, RenderTextureFormat.ARGB32, 0);
         videoRenderTexture.Create();
     }
 


### PR DESCRIPTION
Change to using Display.main.systemWidth & Height for setting the resolution of the video render texture

- [x] Code Review
- [x] Developer Testing: Key item tests