### PR TITLE
tf 170 touch free doesn't interact with settings UI

### DIFF
--- a/TF_Application/Assets/StreamingAssets.meta
+++ b/TF_Application/Assets/StreamingAssets.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: f4ba285d4ec6b9b4ab20fecbfe5dc586
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/TF_Application/Assets/TouchFree_Application/Scenes/TouchlessOverlay.unity
+++ b/TF_Application/Assets/TouchFree_Application/Scenes/TouchlessOverlay.unity
@@ -584,7 +584,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 70b389e418635964082a0a8a2ea324f4, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  functionalityToDisable: {fileID: 1104336824340231345}
+  toolingClientGameobject: {fileID: 1104336824340231345}
+  visibleCanvasses:
+  - {fileID: 1938642279}
+  - {fileID: 7749370175400263840}
 --- !u!4 &1555531686
 Transform:
   m_ObjectHideFlags: 0
@@ -701,6 +704,12 @@ Canvas:
 --- !u!4 &1938642278 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 1583922761665443115, guid: 1287b01b288ed67459e06e84b05eb05e,
+    type: 3}
+  m_PrefabInstance: {fileID: 1938642276}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1938642279 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 8538130551986925400, guid: 1287b01b288ed67459e06e84b05eb05e,
     type: 3}
   m_PrefabInstance: {fileID: 1938642276}
   m_PrefabAsset: {fileID: 0}

--- a/TF_Application/Assets/TouchFree_Application/Scenes/TouchlessOverlay.unity
+++ b/TF_Application/Assets/TouchFree_Application/Scenes/TouchlessOverlay.unity
@@ -584,6 +584,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 70b389e418635964082a0a8a2ea324f4, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  functionalityToDisable: {fileID: 1104336824340231345}
 --- !u!4 &1555531686
 Transform:
   m_ObjectHideFlags: 0

--- a/TF_Application/Assets/TouchFree_Application/Scripts/TouchFreeMain.cs
+++ b/TF_Application/Assets/TouchFree_Application/Scripts/TouchFreeMain.cs
@@ -14,16 +14,18 @@ namespace Ultraleap.TouchFree
         public static int CursorWindowSize = 200;
         public static Vector3 CursorWindowMiddle = new Vector2(100, 100);
 
-        bool settingsOpen = false;
-        public GameObject disableWhenSettingsOpen;
-
         static int minCursorWindowSize = 50;
         static int maxCursorWindowSize = 500;
+
+        bool settingsAppOpen = false;
+
+        public GameObject toolingClientGameobject;
+        public GameObject[] visibleCanvasses;
 
         void Awake()
         {
             Application.targetFrameRate = 60;
-            StartCoroutine(CheckForSettingsOpen());
+            StartCoroutine(CheckForSettingsAppState());
         }
 
         void OnEnable()
@@ -59,7 +61,7 @@ namespace Ultraleap.TouchFree
             CursorWindowMiddle = Vector2.one * (CursorWindowSize / 2);
         }
 
-        IEnumerator CheckForSettingsOpen()
+        IEnumerator CheckForSettingsAppState()
         {
             WaitForSeconds wait = new WaitForSeconds(1);
 
@@ -71,25 +73,50 @@ namespace Ultraleap.TouchFree
 
                 if ((int)hwnd != 0)
                 {
-                    if (!settingsOpen)
+                    if (!settingsAppOpen)
                     {
-                        disableWhenSettingsOpen.SetActive(false);
+                        HandleSettingsAppOpened();
                     }
 
-                    settingsOpen = true;
+                    settingsAppOpen = true;
                 }
                 else
                 {
-                    if (settingsOpen)
+                    if (settingsAppOpen)
                     {
-                        disableWhenSettingsOpen.SetActive(true);
-                        TouchFreeConfigFile.LoadConfig();
+                        HandleSettingsAppClosed();
                     }
 
-                    settingsOpen = false;
+                    settingsAppOpen = false;
                 }
 
                 yield return wait;
+            }
+        }
+
+        void HandleSettingsAppOpened()
+        {
+            SetToolingClientActiveState(false);
+            SetVisibleCanvassesActveState(false);
+        }
+
+        void HandleSettingsAppClosed()
+        {
+            SetToolingClientActiveState(true);
+            SetVisibleCanvassesActveState(true);
+            TouchFreeConfigFile.LoadConfig();
+        }
+
+        void SetToolingClientActiveState(bool _activate)
+        {
+            toolingClientGameobject.SetActive(_activate);
+        }
+
+        void SetVisibleCanvassesActveState(bool _activate)
+        {
+            foreach (var canvas in visibleCanvasses)
+            {
+                canvas.SetActive(_activate);
             }
         }
     }


### PR DESCRIPTION
Added a 1 second timer to check for TouchFreeService.exe being open. If it is, disables the client gameobject (which contains everything) disabling all functionality

- [x] Test plan updated (by PR creator)
- [x] Code Review
- [x] Developer Testing: Key item tests
- [x] Developer Testing: Execution of the updated test plan (changed items for this work only)
- [ ] Product Owner Review (Optional)