### PR TITLE
TF-248: Rationalise units across dot net service

### DIFF
--- a/TF_Service_dotNet/TouchFree/Configuration/ConfigManager.cs
+++ b/TF_Service_dotNet/TouchFree/Configuration/ConfigManager.cs
@@ -15,7 +15,8 @@ namespace Ultraleap.TouchFree.Library.Configuration
             {
                 if (_interactions == null)
                 {
-                    _interactions = InteractionConfigFile.LoadConfig();
+                    InteractionConfigForFile fromFile = InteractionConfigFile.LoadConfig();
+                    _interactions = new InteractionConfig(fromFile);
                 }
 
                 return _interactions;
@@ -32,7 +33,8 @@ namespace Ultraleap.TouchFree.Library.Configuration
             {
                 if (_physical == null)
                 {
-                    _physical = PhysicalConfigFile.LoadConfig();
+                    PhysicalConfigForFile fromFile = PhysicalConfigFile.LoadConfig();
+                    _physical = new PhysicalConfig(fromFile);
                 }
 
                 return _physical;
@@ -45,8 +47,11 @@ namespace Ultraleap.TouchFree.Library.Configuration
 
         public void LoadConfigsFromFiles()
         {
-            _interactions = InteractionConfigFile.LoadConfig();
-            _physical = PhysicalConfigFile.LoadConfig();
+            InteractionConfigForFile intFromFile = InteractionConfigFile.LoadConfig();
+            _interactions = new InteractionConfig(intFromFile);
+
+            PhysicalConfigForFile physFromFile = PhysicalConfigFile.LoadConfig();
+            _physical = new PhysicalConfig(physFromFile);
 
             InteractionConfigWasUpdated();
             PhysicalConfigWasUpdated();

--- a/TF_Service_dotNet/TouchFree/Configuration/InteractionConfig.cs
+++ b/TF_Service_dotNet/TouchFree/Configuration/InteractionConfig.cs
@@ -12,7 +12,7 @@ namespace Ultraleap.TouchFree.Library.Configuration
     [Serializable]
     public class TouchPlaneInteractionSettings
     {
-        public float TouchPlaneActivationDistanceCM = 5f;
+        public float TouchPlaneActivationDistanceMm = 50f;
         public TrackedPosition TouchPlaneTrackedPosition = TrackedPosition.NEAREST;
     }
 
@@ -23,13 +23,52 @@ namespace Ultraleap.TouchFree.Library.Configuration
         public float DeadzoneRadius = 0.003f;
 
         public bool InteractionZoneEnabled = false;
-        public float InteractionMinDistanceCm = 0.0f;
-        public float InteractionMaxDistanceCm = 25.0f;
+        public float InteractionMinDistanceMm = 0.0f;
+        public float InteractionMaxDistanceMm = 250.0f;
 
         public InteractionType InteractionType = InteractionType.PUSH;
 
         // Interaction-specific settings
         public HoverAndHoldInteractionSettings HoverAndHold = new HoverAndHoldInteractionSettings();
         public TouchPlaneInteractionSettings TouchPlane = new TouchPlaneInteractionSettings();
+
+        public InteractionConfig()
+        {
+            this.UseScrollingOrDragging = false;
+            this.DeadzoneRadius = 0.003f;
+
+            this.InteractionZoneEnabled = false;
+            this.InteractionMinDistanceMm = 0.0f;
+            this.InteractionMaxDistanceMm = 250.0f;
+
+            this.InteractionType = InteractionType.PUSH;
+
+            this.HoverAndHold = new HoverAndHoldInteractionSettings();
+            this.TouchPlane = new TouchPlaneInteractionSettings();
+        }
+
+        public InteractionConfig(InteractionConfigForFile fromFile)
+        {
+            this.InteractionMinDistanceMm = fromFile.InteractionMaxDistanceCm * 10f;
+            this.InteractionMaxDistanceMm = fromFile.InteractionMaxDistanceCm * 10f;
+
+            this.UseScrollingOrDragging = fromFile.UseScrollingOrDragging;
+            this.DeadzoneRadius = fromFile.DeadzoneRadius;
+
+            this.InteractionZoneEnabled = fromFile.InteractionZoneEnabled;
+
+            this.InteractionType = fromFile.InteractionType;
+
+            HoverAndHoldInteractionSettings intermedHH = new HoverAndHoldInteractionSettings();
+            intermedHH.HoverStartTimeS = fromFile.HoverAndHold.HoverStartTimeS;
+            intermedHH.HoverCompleteTimeS = fromFile.HoverAndHold.HoverCompleteTimeS;
+
+            TouchPlaneInteractionSettings intermedTP = new TouchPlaneInteractionSettings();
+            intermedTP.TouchPlaneActivationDistanceMm = fromFile.TouchPlane.TouchPlaneActivationDistanceCm * 10f;
+            intermedTP.TouchPlaneTrackedPosition = fromFile.TouchPlane.TouchPlaneTrackedPosition;
+
+            this.HoverAndHold = intermedHH;
+            this.TouchPlane = intermedTP;
+        }
     }
 }

--- a/TF_Service_dotNet/TouchFree/Configuration/InteractionConfigFile.cs
+++ b/TF_Service_dotNet/TouchFree/Configuration/InteractionConfigFile.cs
@@ -1,7 +1,40 @@
-﻿namespace Ultraleap.TouchFree.Library.Configuration
+﻿using System;
+
+namespace Ultraleap.TouchFree.Library.Configuration
 {
-    public class InteractionConfigFile : ConfigFile<InteractionConfig, InteractionConfigFile>
+    public class InteractionConfigFile : ConfigFile<InteractionConfigForFile, InteractionConfigFile>
     {
         protected override string _ConfigFileName => "InteractionConfig.json";
+    }
+
+    [Serializable]
+    public class HoverAndHoldInteractionSettingsForFile
+    {
+        public float HoverStartTimeS = 0.5f;
+        public float HoverCompleteTimeS = 0.6f;
+    }
+
+    [Serializable]
+    public class TouchPlaneInteractionSettingsForFile
+    {
+        public float TouchPlaneActivationDistanceCm = 5f;
+        public TrackedPosition TouchPlaneTrackedPosition = TrackedPosition.NEAREST;
+    }
+
+    [Serializable]
+    public class InteractionConfigForFile
+    {
+        public bool UseScrollingOrDragging = false;
+        public float DeadzoneRadius = 0.003f;
+
+        public bool InteractionZoneEnabled = false;
+        public float InteractionMinDistanceCm = 0.0f;
+        public float InteractionMaxDistanceCm = 25.0f;
+
+        public InteractionType InteractionType = InteractionType.PUSH;
+
+        // Interaction-specific settings
+        public HoverAndHoldInteractionSettingsForFile HoverAndHold = new HoverAndHoldInteractionSettingsForFile();
+        public TouchPlaneInteractionSettingsForFile TouchPlane = new TouchPlaneInteractionSettingsForFile();
     }
 }

--- a/TF_Service_dotNet/TouchFree/Configuration/PhysicalConfig.cs
+++ b/TF_Service_dotNet/TouchFree/Configuration/PhysicalConfig.cs
@@ -6,12 +6,35 @@ namespace Ultraleap.TouchFree.Library.Configuration
     [Serializable]
     public class PhysicalConfig
     {
-        public float ScreenHeightM = 0.33f;
-        public Vector3 LeapPositionRelativeToScreenBottomM = new Vector3(0f, -0.12f, -0.25f);
+        public float ScreenHeightMm = 330f;
+        public Vector3 LeapPositionRelativeToScreenBottomMm = new Vector3(0f, -120f, -250f);
         public Vector3 LeapRotationD = Vector3.Zero;
         public float ScreenRotationD = 0f;
 
         public int ScreenWidthPX = 0;
         public int ScreenHeightPX = 0;
+
+        public PhysicalConfig()
+        {
+            this.ScreenHeightMm = 330f;
+            this.LeapPositionRelativeToScreenBottomMm = new Vector3(0f, -120f, -250f);
+            this.LeapRotationD = Vector3.Zero;
+            this.ScreenRotationD = 0f;
+
+            this.ScreenWidthPX = 0;
+            this.ScreenHeightPX = 0;
+        }
+
+        public PhysicalConfig(PhysicalConfigForFile fromFile)
+        {
+            this.ScreenHeightMm = fromFile.ScreenHeightM * 1000f;
+            this.LeapPositionRelativeToScreenBottomMm = fromFile.LeapPositionRelativeToScreenBottomM * 1000f;
+
+            this.LeapRotationD = fromFile.LeapRotationD;
+            this.ScreenRotationD = fromFile.ScreenRotationD;
+
+            this.ScreenWidthPX = fromFile.ScreenWidthPX;
+            this.ScreenHeightPX = fromFile.ScreenHeightPX;
+        }
     }
 }

--- a/TF_Service_dotNet/TouchFree/Configuration/PhysicalConfigFile.cs
+++ b/TF_Service_dotNet/TouchFree/Configuration/PhysicalConfigFile.cs
@@ -1,7 +1,22 @@
-﻿namespace Ultraleap.TouchFree.Library.Configuration
+﻿using System;
+using System.Numerics;
+
+namespace Ultraleap.TouchFree.Library.Configuration
 {
-    public class PhysicalConfigFile : ConfigFile<PhysicalConfig, PhysicalConfigFile>
+    public class PhysicalConfigFile : ConfigFile<PhysicalConfigForFile, PhysicalConfigFile>
     {
         protected override string _ConfigFileName => "PhysicalConfig.json";
+    }
+
+    [Serializable]
+    public class PhysicalConfigForFile
+    {
+        public float ScreenHeightM = 330f;
+        public Vector3 LeapPositionRelativeToScreenBottomM = new Vector3(0f, -120f, -250f);
+        public Vector3 LeapRotationD = Vector3.Zero;
+        public float ScreenRotationD = 0f;
+
+        public int ScreenWidthPX = 0;
+        public int ScreenHeightPX = 0;
     }
 }

--- a/TF_Service_dotNet/TouchFree/HandManager.cs
+++ b/TF_Service_dotNet/TouchFree/HandManager.cs
@@ -104,27 +104,31 @@ namespace Ultraleap.TouchFree.Library
 
             if (_config.ScreenRotationD != 0)
             {
-                var distanceFromScreenBottom = new Vector(0, _config.LeapPositionRelativeToScreenBottomM.Y, _config.LeapPositionRelativeToScreenBottomM.Z).Magnitude;
-                var angle = Math.Atan(-_config.LeapPositionRelativeToScreenBottomM.Z / _config.LeapPositionRelativeToScreenBottomM.Y);
+                var distanceFromScreenBottom = new Vector(0, _config.LeapPositionRelativeToScreenBottomMm.Y, _config.LeapPositionRelativeToScreenBottomMm.Z).Magnitude;
+                var angle = Math.Atan(-_config.LeapPositionRelativeToScreenBottomMm.Z / _config.LeapPositionRelativeToScreenBottomMm.Y);
                 var angleWithScreenRotation = Utilities.DegreesToRadians(_config.ScreenRotationD) + angle;
 
                 var translatedYPosition = (float)(distanceFromScreenBottom * Math.Cos(angleWithScreenRotation));
-                if (_config.LeapPositionRelativeToScreenBottomM.Z < 0 && _config.LeapPositionRelativeToScreenBottomM.Y < 0) {
+                if (_config.LeapPositionRelativeToScreenBottomMm.Z < 0 && _config.LeapPositionRelativeToScreenBottomMm.Y < 0) {
                     translatedYPosition = -translatedYPosition;
                 }
 
-                var translatedUsingScreenPosition = new Vector(_config.LeapPositionRelativeToScreenBottomM.X, translatedYPosition,
+                var translatedUsingScreenPosition = new Vector(
+                    _config.LeapPositionRelativeToScreenBottomMm.X,
+                    translatedYPosition,
                     (float)(distanceFromScreenBottom * Math.Sin(angleWithScreenRotation)));
 
-                trackingTransform = new LeapTransform(translatedUsingScreenPosition * 1000, new
-                    LeapQuaternion(quaternion.X, quaternion.Y, quaternion.Z, quaternion.W));
+                trackingTransform = new LeapTransform(translatedUsingScreenPosition,
+                    new LeapQuaternion(quaternion.X, quaternion.Y, quaternion.Z, quaternion.W));
             }
             else
             {
-                trackingTransform = new LeapTransform(new Vector(_config.LeapPositionRelativeToScreenBottomM.X,
-                    _config.LeapPositionRelativeToScreenBottomM.Y,
-                    -_config.LeapPositionRelativeToScreenBottomM.Z) * 1000, new
-                    LeapQuaternion(quaternion.X, quaternion.Y, quaternion.Z, quaternion.W));
+                trackingTransform = new LeapTransform(
+                    new Vector(
+                        _config.LeapPositionRelativeToScreenBottomMm.X,
+                        _config.LeapPositionRelativeToScreenBottomMm.Y,
+                        -_config.LeapPositionRelativeToScreenBottomMm.Z),
+                    new LeapQuaternion(quaternion.X, quaternion.Y, quaternion.Z, quaternion.W));
             }
         }
 

--- a/TF_Service_dotNet/TouchFree/IVirtualScreen.cs
+++ b/TF_Service_dotNet/TouchFree/IVirtualScreen.cs
@@ -6,8 +6,8 @@ namespace Ultraleap.TouchFree.Library
     {
         Vector3 VirtualScreenPositionToWorld(Vector2 screenPos, float distanceFromVirtualScreen);
         Vector3 WorldPositionToVirtualScreen(Vector3 worldPosition);
-        Vector2 MetersToPixels(Vector2 position);
-        Vector2 PixelsToMeters(Vector2 position);
-        float MetersToPixels(float distanceM);
+        Vector2 MillimetersToPixels(Vector2 position);
+        Vector2 PixelsToMillimeters(Vector2 position);
+        float MillimetersToPixels(float distanceM);
     }
 }

--- a/TF_Service_dotNet/TouchFree/Interactions/InteractionModules/AirPushInteraction.cs
+++ b/TF_Service_dotNet/TouchFree/Interactions/InteractionModules/AirPushInteraction.cs
@@ -55,7 +55,7 @@ namespace Ultraleap.TouchFree.Library.Interactions
         private bool isDragging = false;
 
         public AirPushInteraction(
-            HandManager _handManager, 
+            HandManager _handManager,
             IVirtualScreen _virtualScreen,
             IConfigManager _configManager,
             IPositioningModule _positioningModule) : base(_handManager, _virtualScreen, _configManager, _positioningModule, TrackedPosition.INDEX_STABLE)
@@ -103,7 +103,7 @@ namespace Ultraleap.TouchFree.Library.Interactions
                 float currentVelocity = dz / dt;    // m/s
 
                 Vector2 dPerpPx = positions.CursorPosition - previousScreenPos;
-                Vector2 dPerp = virtualScreen.PixelsToMeters(dPerpPx);
+                Vector2 dPerp = virtualScreen.PixelsToMillimeters(dPerpPx);
 
                 // Update AppliedForce, which is the crux of the AirPush algorithm
                 float forceChange = GetAppliedForceChange(currentVelocity, dt, dPerp, positions.DistanceFromScreen);
@@ -192,7 +192,7 @@ namespace Ultraleap.TouchFree.Library.Interactions
         {
             float distFromStartPosPx = (_startPos - _currentPos).Length();
 
-            return distFromStartPosPx > virtualScreen.MetersToPixels(dragStartDistanceThresholdM);
+            return distFromStartPosPx > virtualScreen.MillimetersToPixels(dragStartDistanceThresholdM * 1000);
         }
 
         private void AdjustDeadzoneSize(float _df)

--- a/TF_Service_dotNet/TouchFree/Interactions/InteractionModules/GrabInteraction.cs
+++ b/TF_Service_dotNet/TouchFree/Interactions/InteractionModules/GrabInteraction.cs
@@ -77,7 +77,7 @@ namespace Ultraleap.TouchFree.Service
         private void HandleInteractions(Leap.Hand hand, float _velocity)
         {
             // If already pressing, continue regardless of velocity
-            if (grabDetector.IsGrabbing(hand) && (pressing || _velocity < maxHandVelocity))
+            if (grabDetector.IsGrabbing(hand) && (pressing || _velocity < (maxHandVelocity * 1000f)))
             {
                 HandleInvoke();
             }
@@ -195,7 +195,7 @@ namespace Ultraleap.TouchFree.Service
             var b = virtualScreen.VirtualScreenPositionToWorld(_currentPos, 0f);
             var distFromStartPos = (a - b).Length();
 
-            if (distFromStartPos > dragStartDistanceThresholdM)
+            if (distFromStartPos > (dragStartDistanceThresholdM * 1000f))
             {
                 return true;
             }

--- a/TF_Service_dotNet/TouchFree/Interactions/InteractionModules/HoverAndHoldInteraction.cs
+++ b/TF_Service_dotNet/TouchFree/Interactions/InteractionModules/HoverAndHoldInteraction.cs
@@ -53,17 +53,17 @@ namespace Ultraleap.TouchFree.Library.Interactions
                 return;
             }
 
-            Vector2 cursorPositionM = virtualScreen.PixelsToMeters(positions.CursorPosition);
-            Vector2 hoverPosM = ApplyHoverzone(cursorPositionM);
-            positions.CursorPosition = virtualScreen.MetersToPixels(hoverPosM);
+            Vector2 cursorPositionMm = virtualScreen.PixelsToMillimeters(positions.CursorPosition);
+            Vector2 hoverPosMm = ApplyHoverzone(cursorPositionMm);
+            positions.CursorPosition = virtualScreen.MillimetersToPixels(hoverPosMm);
 
             HandleInteractions();
         }
 
-        private Vector2 ApplyHoverzone(Vector2 _screenPosM)
+        private Vector2 ApplyHoverzone(Vector2 _screenPosMm)
         {
             float deadzoneRad = positioningStabiliser.defaultDeadzoneRadius + hoverDeadzoneEnlargementDistance;
-            previousHoverPosDeadzone = positioningStabiliser.ApplyDeadzoneSized(previousHoverPosDeadzone, _screenPosM, deadzoneRad);
+            previousHoverPosDeadzone = positioningStabiliser.ApplyDeadzoneSized(previousHoverPosDeadzone, _screenPosMm, deadzoneRad);
             return previousHoverPosDeadzone;
         }
 

--- a/TF_Service_dotNet/TouchFree/Interactions/InteractionModules/InteractionModule.cs
+++ b/TF_Service_dotNet/TouchFree/Interactions/InteractionModules/InteractionModule.cs
@@ -112,8 +112,8 @@ namespace Ultraleap.TouchFree.Library.Interactions
         {
             if (_hand != null && configManager.InteractionConfig.InteractionZoneEnabled)
             {
-                if (positions.DistanceFromScreen < configManager.InteractionConfig.InteractionMinDistanceCm / 100 ||
-                    positions.DistanceFromScreen > configManager.InteractionConfig.InteractionMaxDistanceCm / 100)
+                if (positions.DistanceFromScreen < configManager.InteractionConfig.InteractionMinDistanceMm / 1000 ||
+                    positions.DistanceFromScreen > configManager.InteractionConfig.InteractionMaxDistanceMm / 1000)
                 {
                     return null;
                 }
@@ -129,8 +129,8 @@ namespace Ultraleap.TouchFree.Library.Interactions
         /// <returns>Returns whether the hand is within the interaction zone.</returns>
         public bool IsHandInInteractionZone()
         {
-            float minInteractionDistanceMeters = configManager.InteractionConfig.InteractionMinDistanceCm / 100;
-            float maxInteractionDistanceMeters = configManager.InteractionConfig.InteractionMaxDistanceCm / 100;
+            float minInteractionDistanceMeters = configManager.InteractionConfig.InteractionMinDistanceMm / 1000;
+            float maxInteractionDistanceMeters = configManager.InteractionConfig.InteractionMaxDistanceMm / 1000;
 
             return !configManager.InteractionConfig.InteractionZoneEnabled ||
                 (positions.DistanceFromScreen >= minInteractionDistanceMeters &&

--- a/TF_Service_dotNet/TouchFree/Interactions/InteractionModules/TouchPlanePushInteraction.cs
+++ b/TF_Service_dotNet/TouchFree/Interactions/InteractionModules/TouchPlanePushInteraction.cs
@@ -9,10 +9,10 @@ namespace Ultraleap.TouchFree.Library.Interactions
     {
         public override InteractionType InteractionType { get; } = InteractionType.TOUCHPLANE;
 
-        // The distance from the touchPlane at which the progressToClick is 0
+        // The distance from the touchPlane (in m) at which the progressToClick is 0
         private const float touchPlaneZeroProgress = 0.1f;
 
-        // The distance from screen at which the progressToClick is 1
+        // The distance from screen (in m) at which the progressToClick is 1
         private float touchPlaneDistance = 0.05f;
 
         private bool pressing = false;
@@ -59,11 +59,13 @@ namespace Ultraleap.TouchFree.Library.Interactions
         {
             Vector2 currentCursorPosition = positions.CursorPosition;
             float distanceFromScreen = positions.DistanceFromScreen;
+            float touchPlaneDistanceMm = touchPlaneDistance * 1000f;
+            float touchPlaneZeroProgressMm = touchPlaneZeroProgress * 1000f;
 
-            float progressToClick = Math.Clamp(1f - Utilities.InverseLerp(touchPlaneDistance, touchPlaneDistance + touchPlaneZeroProgress, distanceFromScreen), 0f, 1f);
+            float progressToClick = Math.Clamp(1f - Utilities.InverseLerp(touchPlaneDistanceMm, touchPlaneDistanceMm + touchPlaneZeroProgressMm, distanceFromScreen), 0f, 1f);
 
             // determine if the fingertip is across one of the surface thresholds (hover/press) and send event
-            if (distanceFromScreen < touchPlaneDistance)
+            if (distanceFromScreen < touchPlaneDistanceMm)
             {
                 if (handReady)
                 {
@@ -121,9 +123,9 @@ namespace Ultraleap.TouchFree.Library.Interactions
 
         private bool CheckForStartDrag(Vector2 _startPos, Vector2 _currentPos)
         {
-            Vector2 startPosM = virtualScreen.PixelsToMeters(_startPos);
-            Vector2 currentPosM = virtualScreen.PixelsToMeters(_currentPos);
-            float distFromStartPos = (startPosM - currentPosM).Length();
+            Vector2 startPosMm = virtualScreen.PixelsToMillimeters(_startPos);
+            Vector2 currentPosMm = virtualScreen.PixelsToMillimeters(_currentPos);
+            float distFromStartPos = (startPosMm - currentPosMm).Length();
 
             if (distFromStartPos > dragStartDistanceThresholdM)
             {
@@ -137,8 +139,8 @@ namespace Ultraleap.TouchFree.Library.Interactions
         {
             base.OnInteractionSettingsUpdated(_config);
 
-            // Convert from CM to M
-            touchPlaneDistance = _config.TouchPlane.TouchPlaneActivationDistanceCM / 100;
+            // Convert from Mm to M
+            touchPlaneDistance = _config.TouchPlane.TouchPlaneActivationDistanceMm / 1000;
             positioningModule.TrackedPosition = _config.TouchPlane.TouchPlaneTrackedPosition;
         }
     }

--- a/TF_Service_dotNet/TouchFree/Interactions/PositionStabiliser.cs
+++ b/TF_Service_dotNet/TouchFree/Interactions/PositionStabiliser.cs
@@ -81,15 +81,16 @@ namespace Ultraleap.TouchFree.Library.Interactions
             return constrainedPositionCurrent;
         }
 
-        public Vector2 ApplyDeadzoneSized(Vector2 previous, Vector2 current, float radius)
+        public Vector2 ApplyDeadzoneSized(Vector2 previous, Vector2 current, float radiusM)
         {
             Vector2 constrainedPosition;
+            float radiusMm = radiusM * 1000f;
 
             float distance = Vector2.Distance(previous, current);
-            if (distance > radius)
+            if (distance > radiusMm)
             {
                 Vector2 unitVector = Vector2.Normalize(previous - current);
-                constrainedPosition = current + (unitVector * radius);
+                constrainedPosition = current + (unitVector * radiusMm);
             }
             else
             {
@@ -132,7 +133,7 @@ namespace Ultraleap.TouchFree.Library.Interactions
             if (previousConstraintVector != Vector2.Zero)
             {
                 float distanceAwayFromConstraint = Vector2.Dot(defaultPositionChange, previousConstraintVector) / previousConstraintVector.Length();
-                distanceAwayFromConstraint = Math.Max(0, distanceAwayFromConstraint);
+                distanceAwayFromConstraint = Math.Max(0, distanceAwayFromConstraint) / 1000;
 
                 float shrinkDistance = distanceAwayFromConstraint * shrinkingSpeed;
                 currentDeadzoneRadius -= shrinkDistance;

--- a/TF_Service_dotNet/TouchFree/Interactions/PositioningModule.cs
+++ b/TF_Service_dotNet/TouchFree/Interactions/PositioningModule.cs
@@ -49,12 +49,12 @@ namespace Ultraleap.TouchFree.Library.Interactions
 
             Vector3 worldPos = TrackerToUse.GetTrackedPosition(hand);
             Vector3 screenPos = virtualScreen.WorldPositionToVirtualScreen(worldPos);
-            Vector2 screenPosM = virtualScreen.PixelsToMeters(new Vector2(screenPos.X, screenPos.Y));
+            Vector2 screenPosMm = virtualScreen.PixelsToMillimeters(new Vector2(screenPos.X, screenPos.Y));
             float distanceFromScreen = screenPos.Z;
 
-            screenPosM = stabiliser.ApplyDeadzone(screenPosM);
+            screenPosMm = stabiliser.ApplyDeadzone(screenPosMm);
 
-            Vector2 oneToOnePosition = virtualScreen.MetersToPixels(screenPosM);
+            Vector2 oneToOnePosition = virtualScreen.MillimetersToPixels(screenPosMm);
 
             // float distanceFromScreen (measured in meters)
             positions.DistanceFromScreen = distanceFromScreen;

--- a/TF_Service_dotNet/TouchFree/VirtualScreen.cs
+++ b/TF_Service_dotNet/TouchFree/VirtualScreen.cs
@@ -9,10 +9,10 @@ namespace Ultraleap.TouchFree.Library
     {
         public float Width_VirtualPx { get; private set; }
         public float Height_VirtualPx { get; private set; }
-        public float Width_PhysicalMeters { get; private set; }
-        public float Height_PhysicalMeters { get; private set; }
+        public float Width_PhysicalMillimeters { get; private set; }
+        public float Height_PhysicalMillimeters { get; private set; }
 
-        public float MetersToPixelsConversion { get; private set; }
+        public float MillimetersToPixelsConversion { get; private set; }
 
         /// <summary>
         ///
@@ -29,13 +29,13 @@ namespace Ultraleap.TouchFree.Library
             Width_VirtualPx = _config.ScreenWidthPX;
             Height_VirtualPx = _config.ScreenHeightPX;
 
-            Height_PhysicalMeters = _config.ScreenHeightM;
+            Height_PhysicalMillimeters = _config.ScreenHeightMm;
             // Calc screen physical width from the physical height and resolution ratio.
             // May not be correct if screen resolution doesn't fill entire physical screen (e.g. 16:9 resolution on a physical 16:10 screen).
             var aspectRatio = (float)_config.ScreenWidthPX / (float)_config.ScreenHeightPX;
-            Width_PhysicalMeters = _config.ScreenHeightM * aspectRatio;
+            Width_PhysicalMillimeters = _config.ScreenHeightMm * aspectRatio;
 
-            MetersToPixelsConversion = Height_VirtualPx / Height_PhysicalMeters;
+            MillimetersToPixelsConversion = Height_VirtualPx / Height_PhysicalMillimeters;
         }
 
         /// <summary>
@@ -52,9 +52,9 @@ namespace Ultraleap.TouchFree.Library
             Vector3 screenPos = Vector3.Zero;
 
             // World X = 0 is middle of screen, so shift everything over by half width (w/2).
-            screenPos.X = (worldPosition.X + (Width_PhysicalMeters / 2.0f)) * MetersToPixelsConversion;
+            screenPos.X = (worldPosition.X + (Width_PhysicalMillimeters / 2.0f)) * MillimetersToPixelsConversion;
             // World Y = 0 is bottom of the screen, so this is linear.
-            screenPos.Y = worldPosition.Y * MetersToPixelsConversion;
+            screenPos.Y = worldPosition.Y * MillimetersToPixelsConversion;
 
             screenPos.Z = worldPosition.Z;
 
@@ -65,8 +65,8 @@ namespace Ultraleap.TouchFree.Library
         {
             Vector3 worldPos = Vector3.Zero;
 
-            worldPos.X = (screenPos.X / MetersToPixelsConversion) - (Width_PhysicalMeters / 2.0f);
-            worldPos.Y = (screenPos.Y / MetersToPixelsConversion);
+            worldPos.X = (screenPos.X / MillimetersToPixelsConversion) - (Width_PhysicalMillimeters / 2.0f);
+            worldPos.Y = (screenPos.Y / MillimetersToPixelsConversion);
             worldPos.Z = distanceFromVirtualScreen;
 
             return worldPos;
@@ -78,9 +78,9 @@ namespace Ultraleap.TouchFree.Library
         //
         // This does not give the "worldPosition", but can be used to calculate distances in pixels
         // instead of metres.
-        public Vector2 PixelsToMeters(Vector2 positionPx)
+        public Vector2 PixelsToMillimeters(Vector2 positionPx)
         {
-            return positionPx / MetersToPixelsConversion;
+            return positionPx / MillimetersToPixelsConversion;
         }
 
         // Perform a unit conversion from meters to pixels
@@ -89,9 +89,9 @@ namespace Ultraleap.TouchFree.Library
         //
         // This does not give the "worldPosition", but can be used to calculate distances in metres
         // instead of pixels.
-        public Vector2 MetersToPixels(Vector2 positionM)
+        public Vector2 MillimetersToPixels(Vector2 positionM)
         {
-            return positionM * MetersToPixelsConversion;
+            return positionM * MillimetersToPixelsConversion;
         }
 
         // Perform a unit conversion from meters to pixels
@@ -100,9 +100,9 @@ namespace Ultraleap.TouchFree.Library
         //
         // This does not give the "worldPosition", but can be used to calculate distances in metres
         // instead of pixels.
-        public float MetersToPixels(float distanceM)
+        public float MillimetersToPixels(float distanceM)
         {
-            return distanceM * MetersToPixelsConversion;
+            return distanceM * MillimetersToPixelsConversion;
         }
 
         [DllImport("User32.dll", ExactSpelling = true, CharSet = CharSet.Auto)]

--- a/TF_Service_dotNet/TouchFreeTests/ConfigManagerTests.cs
+++ b/TF_Service_dotNet/TouchFreeTests/ConfigManagerTests.cs
@@ -19,7 +19,7 @@ namespace TouchFreeTests
         public void UpdateEventPassesPhysicalConfig()
         {
             // Given
-            PhysicalConfig testConfig = new PhysicalConfig { ScreenHeightM = 0.5f };
+            PhysicalConfig testConfig = new PhysicalConfig { ScreenHeightMm = 50f };
             configManager.OnPhysicalConfigUpdated += OnPhysicalConfig;
 
             // When
@@ -28,7 +28,7 @@ namespace TouchFreeTests
 
             // Then
             Assert.IsNotNull(physicalConfig);
-            Assert.AreEqual(0.5f, physicalConfig.ScreenHeightM);
+            Assert.AreEqual(50f, physicalConfig.ScreenHeightMm);
         }
 
         [Test]

--- a/TF_Service_dotNet/TouchFreeTests/Configuration/InteractionConfigTests.cs
+++ b/TF_Service_dotNet/TouchFreeTests/Configuration/InteractionConfigTests.cs
@@ -19,12 +19,12 @@ namespace TouchFreeTests.Configuration
             Assert.AreEqual(false, config.UseScrollingOrDragging);
             Assert.AreEqual(0.003f, config.DeadzoneRadius);
             Assert.AreEqual(false, config.InteractionZoneEnabled);
-            Assert.AreEqual(0.0f, config.InteractionMinDistanceCm);
-            Assert.AreEqual(25.0f, config.InteractionMaxDistanceCm);
+            Assert.AreEqual(0.0f, config.InteractionMinDistanceMm);
+            Assert.AreEqual(250.0f, config.InteractionMaxDistanceMm);
             Assert.AreEqual(InteractionType.PUSH, config.InteractionType);
             Assert.AreEqual(0.5f, config.HoverAndHold.HoverStartTimeS);
             Assert.AreEqual(0.6f, config.HoverAndHold.HoverCompleteTimeS);
-            Assert.AreEqual(5f, config.TouchPlane.TouchPlaneActivationDistanceCM);
+            Assert.AreEqual(50f, config.TouchPlane.TouchPlaneActivationDistanceMm);
             Assert.AreEqual(TrackedPosition.NEAREST, config.TouchPlane.TouchPlaneTrackedPosition);
         }
     }

--- a/TF_Service_dotNet/TouchFreeTests/Configuration/PhysicalConfigTests.cs
+++ b/TF_Service_dotNet/TouchFreeTests/Configuration/PhysicalConfigTests.cs
@@ -15,10 +15,10 @@ namespace TouchFreeTests.Configuration
             config = new PhysicalConfig();
 
             //Then
-            Assert.AreEqual(0.33f, config.ScreenHeightM);
-            Assert.AreEqual(0f, config.LeapPositionRelativeToScreenBottomM.X);
-            Assert.AreEqual(-0.12f, config.LeapPositionRelativeToScreenBottomM.Y);
-            Assert.AreEqual(-0.25f, config.LeapPositionRelativeToScreenBottomM.Z);
+            Assert.AreEqual(330f, config.ScreenHeightMm);
+            Assert.AreEqual(0f, config.LeapPositionRelativeToScreenBottomMm.X);
+            Assert.AreEqual(-120f, config.LeapPositionRelativeToScreenBottomMm.Y);
+            Assert.AreEqual(-250f, config.LeapPositionRelativeToScreenBottomMm.Z);
             Assert.AreEqual(0f, config.LeapRotationD.X);
             Assert.AreEqual(0f, config.LeapRotationD.Y);
             Assert.AreEqual(0f, config.LeapRotationD.Z);

--- a/TF_Service_dotNet/TouchFreeTests/HandManagerTests.cs
+++ b/TF_Service_dotNet/TouchFreeTests/HandManagerTests.cs
@@ -19,14 +19,14 @@ namespace TouchFreeTests
         {
             // Given
             HandManager handManger = new (null, null);
-            System.Numerics.Vector3 translationInMeters = new (0.1f, 0.2f, 0.3f);
-            Leap.Vector translationInLeapSpace = new Leap.Vector(translationInMeters.X, translationInMeters.Y, -translationInMeters.Z) * 1000;
-            PhysicalConfig testConfig = new () { LeapPositionRelativeToScreenBottomM = translationInMeters };
+            System.Numerics.Vector3 translationInMillimeters = new (100f, 200f, 300f);
+            Leap.Vector translationInLeapSpace = new Leap.Vector(translationInMillimeters.X, translationInMillimeters.Y, -translationInMillimeters.Z);
+            PhysicalConfig testConfig = new () { LeapPositionRelativeToScreenBottomMm = translationInMillimeters };
 
-            // When 
+            // When
             handManger.UpdateTrackingTransform(testConfig);
 
-            // Then 
+            // Then
             Assert.AreEqual(translationInLeapSpace, handManger.TrackingTransform().translation);
         }
 
@@ -37,7 +37,7 @@ namespace TouchFreeTests
             HandManager handManger = new (null, null);
             System.Numerics.Vector3 topDownRotation = new (45, 0, 180);
             System.Numerics.Quaternion topDownQuaternion = System.Numerics.Quaternion.CreateFromYawPitchRoll(
-                Utilities.DegreesToRadians(topDownRotation.Y), 
+                Utilities.DegreesToRadians(topDownRotation.Y),
                 Utilities.DegreesToRadians(topDownRotation.X),
                 Utilities.DegreesToRadians(topDownRotation.Z));
 
@@ -46,7 +46,7 @@ namespace TouchFreeTests
             //When
             handManger.UpdateTrackingTransform(testConfig);
 
-            //Then 
+            //Then
             System.Numerics.Quaternion handManagerRotation = new ()
             {
                 X = handManger.TrackingTransform().rotation.x,
@@ -73,7 +73,7 @@ namespace TouchFreeTests
             //When
             handManger.UpdateTrackingTransform(testConfig);
 
-            //Then 
+            //Then
             System.Numerics.Quaternion handManagerRotation = new ()
             {
                 X = handManger.TrackingTransform().rotation.x,
@@ -90,15 +90,15 @@ namespace TouchFreeTests
             // Given
             HandManager handManger = new(null, null);
             System.Numerics.Vector3 bottomRotation = new(45, 0, 0);
-            System.Numerics.Vector3 relativePosition = new(1, 2, 3);
+            System.Numerics.Vector3 relativePosition = new(1000, 2000, 3000);
             System.Numerics.Vector3 positionTranslation = new(1000, 2000, -3000);
 
-            PhysicalConfig testConfig = new() { LeapRotationD = bottomRotation, LeapPositionRelativeToScreenBottomM = relativePosition };
+            PhysicalConfig testConfig = new() { LeapRotationD = bottomRotation, LeapPositionRelativeToScreenBottomMm = relativePosition };
 
             //When
             handManger.UpdateTrackingTransform(testConfig);
 
-            //Then 
+            //Then
             System.Numerics.Vector3 handManagerRelativePosition = new()
             {
                 X = handManger.TrackingTransform().translation.x,
@@ -114,10 +114,10 @@ namespace TouchFreeTests
             // Given
             HandManager handManger = new(null, null);
             System.Numerics.Vector3 bottomRotation = new(45, 0, 0);
-            System.Numerics.Vector3 relativePosition = new(1, 1, 1);
+            System.Numerics.Vector3 relativePosition = new(1000, 1000, 1000);
             System.Numerics.Vector3 positionTranslation = new(1000, 1158.46f, -811.16f);
 
-            PhysicalConfig testConfig = new() { LeapRotationD = bottomRotation, LeapPositionRelativeToScreenBottomM = relativePosition, ScreenRotationD = 10 };
+            PhysicalConfig testConfig = new() { LeapRotationD = bottomRotation, LeapPositionRelativeToScreenBottomMm = relativePosition, ScreenRotationD = 10 };
 
             //When
             handManger.UpdateTrackingTransform(testConfig);

--- a/TF_Service_dotNet/TouchFreeTests/PositionStabiliserTests.cs
+++ b/TF_Service_dotNet/TouchFreeTests/PositionStabiliserTests.cs
@@ -52,15 +52,15 @@ namespace TouchFreeTests
 
         private static object[] applyDeadzoneSizedCases = new[]
         {
-            new object[] { new Vector2(1.5f, 1f), new Vector2(1.4f, 1f)},
-            new object[] { new Vector2(1f, 1.5f), new Vector2(1f, 1.4f)}
+            new object[] { new Vector2(1500f, 1000f), new Vector2(1400f, 1000f)},
+            new object[] { new Vector2(1000f, 1500f), new Vector2(1000f, 1400f)}
         };
 
         [TestCaseSource(nameof(applyDeadzoneSizedCases))]
         public void ApplyDeadzoneSized_NewPositionOutsideDeadzone_ReturnsCurrentPositionReducedByTheDeadzone(Vector2 currentPosition, Vector2 expectedPosition)
         {
             //Given
-            Vector2 previousPosition = new Vector2(1, 1);
+            Vector2 previousPosition = new Vector2(1000, 1000);
             float deadzoneRadius = 0.1f;
             PositionStabiliser positionStabiliser = CreatePositionStabiliser();
 
@@ -123,15 +123,15 @@ namespace TouchFreeTests
             Assert.AreEqual(previousPosition.Y, result.Y);
         }
 
-        [TestCase(1, 1.60000f, 2.400f)]
-        [TestCase(2, 1.4000f, 4.600f)]
-        [TestCase(3, 1.2000f, 6.800f)]
-        [TestCase(4, 1.0000f, 9.000f)]
-        [TestCase(5, 0.8000f, 11.200f)]
+        [TestCase(1, 1.6000f,  2400f)]
+        [TestCase(2, 1.4000f,  4600f)]
+        [TestCase(3, 1.2000f,  6800f)]
+        [TestCase(4, 1.0000f,  9000f)]
+        [TestCase(5, 0.8000f, 11200f)]
         public void ApplyDeadzone_StartShrinkingDeadzone_CurrentDeadzoneRadiusDecreases(int cursorMovementCount, float expectedDeadzoneSize, float expectedCursorY)
         {
             //Given
-            Vector2 previousPosition = new Vector2(1, 2);
+            Vector2 previousPosition = new Vector2(1000f, 2000f);
             PositionStabiliser positionStabiliser = CreatePositionStabiliser();
             positionStabiliser.defaultDeadzoneRadius = 0.2f;
             positionStabiliser.currentDeadzoneRadius = 1.6f;
@@ -142,14 +142,14 @@ namespace TouchFreeTests
             Vector2 result = previousPosition;
             for (var i = 1; i <= cursorMovementCount; i++)
             {
-                Vector2 newPosition = Vector2.Add(previousPosition, new Vector2(0, 2 * i));
+                Vector2 newPosition = Vector2.Add(previousPosition, new Vector2(0, 2000f * i));
                 result = positionStabiliser.ApplyDeadzone(newPosition);
             }
 
             //Then
-            Assert.AreEqual(1f, result.X, 0.001);
-            Assert.AreEqual(expectedCursorY, result.Y, 0.001);
             Assert.AreEqual(expectedDeadzoneSize, positionStabiliser.currentDeadzoneRadius, 0.0001);
+            Assert.AreEqual(1000f, result.X, 0.001);
+            Assert.AreEqual(expectedCursorY, result.Y, 0.01);
         }
 
         [TestCase(1)]
@@ -184,20 +184,20 @@ namespace TouchFreeTests
         public void ApplyDeadzone_DeadzoneOffsetApplied_OffsetAppliedOnSubsequentMovement()
         {
             //Given
-            Vector2 previousPosition = new Vector2(1, 2);
+            Vector2 previousPosition = new Vector2(1000f, 2000f);
             PositionStabiliser positionStabiliser = CreatePositionStabiliser();
             positionStabiliser.defaultDeadzoneRadius = 0.2f;
             positionStabiliser.currentDeadzoneRadius = 1f;
             positionStabiliser.ApplyDeadzone(previousPosition);
-            positionStabiliser.ApplyDeadzone(new Vector2(1, 2.5f));
+            positionStabiliser.ApplyDeadzone(new Vector2(1000, 2500f));
             positionStabiliser.SetDeadzoneOffset();
 
             //When
-            var result = positionStabiliser.ApplyDeadzone(new Vector2(1, 5));
+            var result = positionStabiliser.ApplyDeadzone(new Vector2(1000, 5000));
 
             //Then
-            Assert.AreEqual(1f, result.X, 0.001);
-            Assert.AreEqual(3.5f, result.Y, 0.001);
+            Assert.AreEqual(1000f, result.X, 0.001);
+            Assert.AreEqual(3500f, result.Y, 0.001);
             Assert.AreEqual(1f, positionStabiliser.currentDeadzoneRadius, 0.0001);
         }
 
@@ -205,21 +205,21 @@ namespace TouchFreeTests
         public void ApplyDeadzone_DeadzoneOffsetReduced_OffsetIsReduced()
         {
             //Given
-            Vector2 previousPosition = new Vector2(1, 2);
+            Vector2 previousPosition = new Vector2(1000, 2000);
             PositionStabiliser positionStabiliser = CreatePositionStabiliser();
             positionStabiliser.defaultDeadzoneRadius = 0.2f;
             positionStabiliser.currentDeadzoneRadius = 1f;
             positionStabiliser.ApplyDeadzone(previousPosition);
-            positionStabiliser.ApplyDeadzone(new Vector2(1, 2.5f));
+            positionStabiliser.ApplyDeadzone(new Vector2(1000, 2500f));
             positionStabiliser.SetDeadzoneOffset();
             positionStabiliser.ReduceDeadzoneOffset();
 
             //When
-            var result = positionStabiliser.ApplyDeadzone(new Vector2(1, 5));
+            var result = positionStabiliser.ApplyDeadzone(new Vector2(1000, 5000));
 
             //Then
-            Assert.AreEqual(1f, result.X, 0.001);
-            Assert.AreEqual(3.55f, result.Y, 0.001);
+            Assert.AreEqual(1000f, result.X, 0.001);
+            Assert.AreEqual(3550f, result.Y, 0.001);
             Assert.AreEqual(1f, positionStabiliser.currentDeadzoneRadius, 0.0001);
         }
     }

--- a/TF_Service_dotNet/TouchFreeTests/PositioningModuleTests.cs
+++ b/TF_Service_dotNet/TouchFreeTests/PositioningModuleTests.cs
@@ -43,15 +43,15 @@ namespace TouchFreeTests
             //Given
             Vector3 worldPosition = new Vector3(1, 2, 3);
             Vector3 screenPosition = new Vector3(4, 5, 6);
-            Vector2 screenPositionM = new Vector2(7, 8);
+            Vector2 screenPositionMm = new Vector2(7, 8);
 
             SetTrackerPosition(TrackedPosition.INDEX_TIP, worldPosition);
 
             PositioningModule positioningModule = CreatePositioningModule(new[] { mockTracker.Object });
 
             mockVirtualScreen.Setup(x => x.WorldPositionToVirtualScreen(worldPosition)).Returns(screenPosition);
-            mockVirtualScreen.Setup(x => x.PixelsToMeters(It.Is<Vector2>(v => v.X == screenPosition.X && v.Y == screenPosition.Y))).Returns(screenPositionM);
-            mockVirtualScreen.Setup(x => x.MetersToPixels(screenPositionM)).Returns(new Vector2(screenPosition.X, screenPosition.Y));
+            mockVirtualScreen.Setup(x => x.PixelsToMillimeters(It.Is<Vector2>(v => v.X == screenPosition.X && v.Y == screenPosition.Y))).Returns(screenPositionMm);
+            mockVirtualScreen.Setup(x => x.MillimetersToPixels(screenPositionMm)).Returns(new Vector2(screenPosition.X, screenPosition.Y));
 
             Vector2 expectedHandPositionPx = new Vector2(4, 5);
             float expectedDistanceFromScreenM = 6;
@@ -71,15 +71,15 @@ namespace TouchFreeTests
             //Given
             Vector3 worldPosition = new Vector3(1, 2, 3);
             Vector3 screenPosition = new Vector3(4, 5, 6);
-            Vector2 screenPositionM = new Vector2(7, 8);
+            Vector2 screenPositionMm = new Vector2(7, 8);
 
             SetTrackerPosition(TrackedPosition.INDEX_TIP, worldPosition);
 
             PositioningModule positioningModule = CreatePositioningModule(new[] { mockTracker.Object });
 
             mockVirtualScreen.Setup(x => x.WorldPositionToVirtualScreen(worldPosition)).Returns(screenPosition);
-            mockVirtualScreen.Setup(x => x.PixelsToMeters(It.Is<Vector2>(v => v.X == screenPosition.X && v.Y == screenPosition.Y))).Returns(screenPositionM);
-            mockVirtualScreen.Setup(x => x.MetersToPixels(screenPositionM)).Returns(new Vector2(screenPosition.X, screenPosition.Y));
+            mockVirtualScreen.Setup(x => x.PixelsToMillimeters(It.Is<Vector2>(v => v.X == screenPosition.X && v.Y == screenPosition.Y))).Returns(screenPositionMm);
+            mockVirtualScreen.Setup(x => x.MillimetersToPixels(screenPositionMm)).Returns(new Vector2(screenPosition.X, screenPosition.Y));
 
             Ultraleap.TouchFree.Library.Positions oldPosition = positioningModule.CalculatePositions(new Leap.Hand());
 
@@ -93,12 +93,12 @@ namespace TouchFreeTests
             Ultraleap.TouchFree.Library.Positions position = positioningModule.CalculatePositions(null);
 
             //Then
-            Assert.AreEqual(oldPosition.CursorPosition.X, position.CursorPosition.X, 0.001);
-            Assert.AreEqual(oldPosition.CursorPosition.Y, position.CursorPosition.Y, 0.001);
-            Assert.AreEqual(oldPosition.DistanceFromScreen, position.DistanceFromScreen, 0.001);
-            Assert.AreEqual(expectedHandPositionPx.X, position.CursorPosition.X, 0.001);
-            Assert.AreEqual(expectedHandPositionPx.Y, position.CursorPosition.Y, 0.001);
-            Assert.AreEqual(expectedDistanceFromScreenM, position.DistanceFromScreen, 0.001);
+            Assert.AreEqual(oldPosition.CursorPosition.X, position.CursorPosition.X, 0.01);
+            Assert.AreEqual(oldPosition.CursorPosition.Y, position.CursorPosition.Y, 0.01);
+            Assert.AreEqual(oldPosition.DistanceFromScreen, position.DistanceFromScreen, 0.01);
+            Assert.AreEqual(expectedHandPositionPx.X, position.CursorPosition.X, 0.01);
+            Assert.AreEqual(expectedHandPositionPx.Y, position.CursorPosition.Y, 0.01);
+            Assert.AreEqual(expectedDistanceFromScreenM, position.DistanceFromScreen, 0.01);
         }
 
         [TestCase(TrackedPosition.INDEX_TIP, typeof(IndexTipTracker))]

--- a/TF_Service_dotNet/TouchFreeTests/VirtualScreenTests.cs
+++ b/TF_Service_dotNet/TouchFreeTests/VirtualScreenTests.cs
@@ -23,9 +23,9 @@ namespace TouchFreeTests
             //Given
             IConfigManager configManager = CreateMockedConfigManager(new PhysicalConfig()
             {
-                ScreenWidthPX = 1080, 
+                ScreenWidthPX = 1080,
                 ScreenHeightPX = 1920,
-                ScreenHeightM = 0.4f,
+                ScreenHeightMm = 400f,
                 ScreenRotationD = 0
             });
 
@@ -35,13 +35,13 @@ namespace TouchFreeTests
             //Then
             Assert.AreEqual(1080, virtualScreen.Width_VirtualPx);
             Assert.AreEqual(1920, virtualScreen.Height_VirtualPx);
-            Assert.AreEqual(0.4f, virtualScreen.Height_PhysicalMeters);
-            Assert.AreEqual(0.225f, virtualScreen.Width_PhysicalMeters, 0.001);
+            Assert.AreEqual(400f, virtualScreen.Height_PhysicalMillimeters);
+            Assert.AreEqual(225f, virtualScreen.Width_PhysicalMillimeters, 0.01);
         }
 
         private int ScreenWidthInPixels = 1080;
         private int ScreenHeightInPixels = 1920;
-        private float ScreenHeightInMeters = 0.4f;
+        private float ScreenHeightInMeters = 400f;
 
         private VirtualScreen CreateVirtualScreen()
         {
@@ -49,7 +49,7 @@ namespace TouchFreeTests
             {
                 ScreenWidthPX = ScreenWidthInPixels,
                 ScreenHeightPX = ScreenHeightInPixels,
-                ScreenHeightM = ScreenHeightInMeters
+                ScreenHeightMm = ScreenHeightInMeters
             };
             IConfigManager configManager = CreateMockedConfigManager(physicalConfig);
 
@@ -58,8 +58,8 @@ namespace TouchFreeTests
 
         private static object[] pixelsToMetersCases = new object[]
         {
-            new[] { new Vector2 (480, 960), new Vector2 (0.1f, 0.2f) },
-            new[] { new Vector2 (0, 540), new Vector2 (0f, 0.1125f) }
+            new[] { new Vector2 (480, 960), new Vector2 (100f, 200f) },
+            new[] { new Vector2 (0, 540), new Vector2 (0f, 112.5f) }
         };
 
         [TestCaseSource(nameof(pixelsToMetersCases))]
@@ -69,42 +69,42 @@ namespace TouchFreeTests
             VirtualScreen virtualScreen = CreateVirtualScreen();
 
             //When
-            Vector2 meterPosition = virtualScreen.PixelsToMeters(positionPx);
+            Vector2 meterPosition = virtualScreen.PixelsToMillimeters(positionPx);
 
             //Then
-            Assert.AreEqual(expectedPositionM.X, meterPosition.X, 0.0001);
-            Assert.AreEqual(expectedPositionM.Y, meterPosition.Y, 0.0001);
+            Assert.AreEqual(expectedPositionM.X, meterPosition.X, 0.01);
+            Assert.AreEqual(expectedPositionM.Y, meterPosition.Y, 0.01);
         }
 
         private static object[] metersToPixelsCases = new object[]
         {
-            new[] { new Vector2 (0.1f, 0.2f), new Vector2 (480, 960) },
-            new[] { new Vector2(0f, 0.1125f), new Vector2 (0, 540) }
+            new[] { new Vector2 (100f, 200f), new Vector2 (480, 960) },
+            new[] { new Vector2(0f, 112.5f), new Vector2 (0, 540) }
         };
 
         [TestCaseSource(nameof(metersToPixelsCases))]
-        public void MetersToPixels_ConvertsMeterPositionToPixels(Vector2 positionM, Vector2 expectedPositionPx)
+        public void MetersToPixels_ConvertsMeterPositionToPixels(Vector2 positionMm, Vector2 expectedPositionPx)
         {
             //Given
             VirtualScreen virtualScreen = CreateVirtualScreen();
 
             //When
-            Vector2 pixelPosition = virtualScreen.MetersToPixels(positionM);
+            Vector2 pixelPosition = virtualScreen.MillimetersToPixels(positionMm);
 
             //Then
-            Assert.AreEqual(expectedPositionPx.X, pixelPosition.X, 0.0001);
-            Assert.AreEqual(expectedPositionPx.Y, pixelPosition.Y, 0.0001);
+            Assert.AreEqual(expectedPositionPx.X, pixelPosition.X, 0.01);
+            Assert.AreEqual(expectedPositionPx.Y, pixelPosition.Y, 0.01);
         }
 
-        [TestCase(0.1f, 480)]
+        [TestCase(100f, 480)]
         [TestCase(0, 0)]
-        public void MetersToPixels_ConvertsMeterPositionToPixels(float positionM, float expectedPositionPx)
+        public void MetersToPixels_ConvertsMeterPositionToPixels(float positionMm, float expectedPositionPx)
         {
             //Given
             VirtualScreen virtualScreen = CreateVirtualScreen();
 
             //When
-            float pixelPosition = virtualScreen.MetersToPixels(positionM);
+            float pixelPosition = virtualScreen.MillimetersToPixels(positionMm);
 
             //Then
             Assert.AreEqual(expectedPositionPx, pixelPosition, 0.0001);
@@ -128,19 +128,19 @@ namespace TouchFreeTests
 
         private static object[] worldPositionToVirtualScreenUnangledScreenCases = new object[]
         {
-            new object[] { new Vector3(0.1f, 0, 1), new Vector3(1020, 0, 1) },
-            new object[] { new Vector3(-0.1f, 0.1f, 1), new Vector3(60, 480, 1) },
-            new object[] { new Vector3(0, 0.15f, 2), new Vector3(540, 720, 2) },
+            new object[] { new Vector3(100f, 0, 1000f), new Vector3(1020, 0, 1000f) },
+            new object[] { new Vector3(-100f, 100f, 1000f), new Vector3(60, 480, 1000f) },
+            new object[] { new Vector3(0, 150f, 2000f), new Vector3(540, 720, 2000f) },
         };
 
         [TestCaseSource(nameof(worldPositionToVirtualScreenUnangledScreenCases))]
-        public void WorldPositionToVirtualScreen_ReturnsMappedPosition(Vector3 worldPositionM, Vector3 expectedScreenPosition)
+        public void WorldPositionToVirtualScreen_ReturnsMappedPosition(Vector3 worldPositionMm, Vector3 expectedScreenPosition)
         {
             //Given
             VirtualScreen virtualScreen = CreateVirtualScreen();
 
             //When
-            var screenPosition = virtualScreen.WorldPositionToVirtualScreen(worldPositionM);
+            var screenPosition = virtualScreen.WorldPositionToVirtualScreen(worldPositionMm);
 
             //Then
             Assert.AreEqual(expectedScreenPosition.X, screenPosition.X, 0.001);

--- a/TF_Service_dotNet/TouchFree_Service/Startup.cs
+++ b/TF_Service_dotNet/TouchFree_Service/Startup.cs
@@ -44,7 +44,7 @@ namespace Ultraleap.TouchFree.Service
             // This is here so the test infrastructure has some sign that the app is ready
             Console.WriteLine("Service Setup Complete");
 
-            Console.WriteLine("TouchFree physical config screen height is: " + configManager.PhysicalConfig.ScreenHeightM);
+            Console.WriteLine("TouchFree physical config screen height is: " + configManager.PhysicalConfig.ScreenHeightMm + " mm");
         }
     }
 }


### PR DESCRIPTION
- [ ] Code Review 
- [ ] Developer Testing: Key item tests 

Unify measurement units (to mm) across the .net service, with two exceptions:

* Values measured in M within interactions themselves, as these are under change at the moment
* Deadzone sizes, as deadzone is tied with Hover and Hold. I will maybe do this in another pass if we thing it should be done.