### PR TITLE
Ensure logfile directory is created before trying to use it

### DIFF
--- a/TF_Service_dotNet/TouchFree_Service/Program.cs
+++ b/TF_Service_dotNet/TouchFree_Service/Program.cs
@@ -16,7 +16,9 @@ namespace Ultraleap.TouchFree.Service
 #if !DEBUG
             var loggingFileDirectory = RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ? ConfigFileUtils.ConfigFileDirectory : "";
 
-            Directory.CreateDirectory(loggingFileDirectory);
+            if (loggingFileDirectory != "") {
+                Directory.CreateDirectory(loggingFileDirectory);
+            }
 
             FileStream filestream = new FileStream(loggingFileDirectory + "log.txt", FileMode.Create);
             StreamWriter streamwriter = new StreamWriter(filestream)

--- a/TF_Service_dotNet/TouchFree_Service/Program.cs
+++ b/TF_Service_dotNet/TouchFree_Service/Program.cs
@@ -15,6 +15,9 @@ namespace Ultraleap.TouchFree.Service
         {
 #if !DEBUG
             var loggingFileDirectory = RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ? ConfigFileUtils.ConfigFileDirectory : "";
+
+            Directory.CreateDirectory(loggingFileDirectory);
+
             FileStream filestream = new FileStream(loggingFileDirectory + "log.txt", FileMode.Create);
             StreamWriter streamwriter = new StreamWriter(filestream)
             {


### PR DESCRIPTION
This resolves an issue with starting the TouchFree Service on BS, enabling me to test 361 on the box (which was successful).

- [ ] Code Review 
- [ ] Developer Testing: Key item tests 
- [ ] Developer Testing: Execution of the updated test plan (changed items for this work only) 
- [ ] QA Review