### PR TITLE
TF-498 - Tracking installer is left in the TouchFree directory after install

### DIFF
--- a/TF_Service_Utilities/Installer/TouchFree_Installer.iss
+++ b/TF_Service_Utilities/Installer/TouchFree_Installer.iss
@@ -49,7 +49,7 @@ Name: "english"; MessagesFile: "compiler:Default.isl"
 [Files]
 Source: "{#SourcePath}..\..\Service_Package\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
 Source: "{#SourcePath}..\..\TouchFree_Build\*"; DestDir: "{app}\TouchFree"; Flags: ignoreversion recursesubdirs createallsubdirs
-Source: "{#SourcePath}..\..\Scripts\Tracking_Build\Tracking_for_TouchFree_{#TouchFreeVersion}.exe"; DestDir: "{app}\Tracking"; Flags: ignoreversion
+Source: "{#SourcePath}..\..\Scripts\Tracking_Build\Tracking_for_TouchFree_{#TouchFreeVersion}.exe"; DestDir: "{app}\Tracking"; Flags: ignoreversion deleteafterinstall
 ; NOTE: Don't use "Flags: ignoreversion" on any shared system files
 
 [Icons]


### PR DESCRIPTION
Sets the flag `deleteafterinstall` on the tracking installer so that the installation removes it after all installation steps have been completed.