### PR TITLE
Feature/tf 650 camera connection events

### DIFF
--- a/TF_Service_dotNet/TouchFree/Configuration/ConfigFile.cs
+++ b/TF_Service_dotNet/TouchFree/Configuration/ConfigFile.cs
@@ -14,17 +14,7 @@ namespace Ultraleap.TouchFree.Library.Configuration
         #region Singleton
 
         protected static UThisClass _instance;
-        protected static UThisClass Instance
-        {
-            get
-            {
-                if (_instance == null)
-                {
-                    _instance = new UThisClass();
-                }
-                return _instance;
-            }
-        }
+        protected static UThisClass Instance => _instance ??= new UThisClass();
 
         #endregion
 

--- a/TF_Service_dotNet/TouchFree/Configuration/ConfigFile.cs
+++ b/TF_Service_dotNet/TouchFree/Configuration/ConfigFile.cs
@@ -7,23 +7,33 @@ using System.Runtime.InteropServices;
 
 namespace Ultraleap.TouchFree.Library.Configuration
 {
-    public abstract class ConfigFile<TData, UThisClass>
-    where TData : class, new()
-    where UThisClass : ConfigFile<TData, UThisClass>, new()
+    public abstract class ConfigFile<TData, TThisClass>
+        where TData : class, new()
+        where TThisClass : ConfigFile<TData, TThisClass>, new()
     {
         #region Singleton
 
-        protected static UThisClass _instance;
-        protected static UThisClass Instance => _instance ??= new UThisClass();
+        private static TThisClass _instance;
+        protected static TThisClass Instance => _instance ??= new TThisClass();
 
         #endregion
 
         #region Public
 
+        // ReSharper disable once StaticMemberInGenericType - by design, each derived type will have its own sync root
+        // NOTE: If multiple derived classes use the same types they will share a sync root!
+        public static readonly object SaveConfigSyncRoot = new();
+        
+        public static event Action OnConfigFileSaved
+        {
+            add => Instance._OnConfigFileSaved += value;
+            remove => Instance._OnConfigFileSaved -= value;
+        }
+
         public static event Action OnConfigFileUpdated
         {
-            add { Instance._OnConfigFileUpdated += value; }
-            remove { Instance._OnConfigFileUpdated -= value; }
+            add => Instance._OnConfigFileUpdated += value;
+            remove => Instance._OnConfigFileUpdated -= value;
         }
 
         protected abstract string _ConfigFileName { get; }
@@ -31,36 +41,30 @@ namespace Ultraleap.TouchFree.Library.Configuration
         public static string ConfigFilePath => Instance._ConfigFilePath;
         public static string ConfigFileName => Instance._ConfigFileName;
 
-        public static TData LoadConfig()
-        {
-            return Instance.LoadConfig_Internal();
-        }
+        public static TData LoadConfig() => Instance.LoadConfig_Internal();
 
         public static void SaveConfig(TData newConfig)
         {
-            Instance.SaveConfig_Internal(newConfig);
+            lock (SaveConfigSyncRoot)
+            {
+                Instance.WriteConfigToFile(newConfig);
+                Instance._OnConfigFileSaved?.Invoke();
+            }
         }
 
-        public static TData GetDefaultValues()
-        {
-            return new TData();
-        }
-
-        public static bool ErrorLoadingConfiguration()
-        {
-            return Instance.ErrorLoadingConfig;
-        }
+        public static bool ErrorLoadingConfiguration() => Instance.ErrorLoadingConfig;
 
         #endregion
 
         #region Internal
 
+        private event Action _OnConfigFileSaved;
         private event Action _OnConfigFileUpdated;
         protected virtual string _ConfigFilePath => Path.Combine(ConfigFileUtils.ConfigFileDirectory, ConfigFileName);
 
         public bool ErrorLoadingConfig { get; private set; } = false;
 
-        protected TData LoadConfig_Internal()
+        private TData LoadConfig_Internal()
         {
             if (!DoesConfigFileExist())
             {
@@ -87,11 +91,6 @@ namespace Ultraleap.TouchFree.Library.Configuration
             _OnConfigFileUpdated?.Invoke();
 
             return config;
-        }
-
-        protected void SaveConfig_Internal(TData config)
-        {
-            WriteConfigToFile(config);
         }
 
         protected TData DeserialiseRawText(string rawText)
@@ -164,14 +163,14 @@ namespace Ultraleap.TouchFree.Library.Configuration
                     DirectoryInfo dirInfo = new DirectoryInfo(ConfigFileUtils.ConfigFileDirectory);
 
                     // Create the directory and request permissions to it for all users
-                    DirectorySecurity directorySecurity = FileSystemAclExtensions.GetAccessControl(dirInfo);
+                    DirectorySecurity directorySecurity = dirInfo.GetAccessControl();
                     directorySecurity.ModifyAccessRule(AccessControlModification.Add, rule, out _);
-                    FileSystemAclExtensions.SetAccessControl(dirInfo, directorySecurity);
+                    dirInfo.SetAccessControl(directorySecurity);
                 }
             }
             catch
             {
-                TouchFreeLog.WriteLine("Did not have permissios to set file access rules");
+                TouchFreeLog.WriteLine("Did not have permissions to set file access rules");
             }
         }
 

--- a/TF_Service_dotNet/TouchFree/Configuration/ConfigManager.cs
+++ b/TF_Service_dotNet/TouchFree/Configuration/ConfigManager.cs
@@ -6,10 +6,16 @@ namespace Ultraleap.TouchFree.Library.Configuration
     {
         public event IConfigManager.InteractionConfigEvent OnInteractionConfigUpdated;
         public event IConfigManager.PhysicalConfigEvent OnPhysicalConfigUpdated;
+        public event IConfigManager.TrackingConfigEvent OnTrackingConfigSaved;
         public event IConfigManager.TrackingConfigEvent OnTrackingConfigUpdated;
         private InteractionConfigInternal _interactions;
         private PhysicalConfigInternal _physical;
         private TrackingConfig _tracking;
+
+        public ConfigManager()
+        {
+            TrackingConfigFile.OnConfigFileSaved += () => OnTrackingConfigSaved?.Invoke();
+        }
 
         public bool ErrorLoadingConfigFiles { get; private set; }
 
@@ -102,20 +108,10 @@ namespace Ultraleap.TouchFree.Library.Configuration
             ErrorLoadingConfigFiles = InteractionConfigFile.ErrorLoadingConfiguration() || PhysicalConfigFile.ErrorLoadingConfiguration();
         }
 
-        public void PhysicalConfigWasUpdated()
-        {
-            OnPhysicalConfigUpdated?.Invoke(_physical);
-        }
-
-        public void InteractionConfigWasUpdated()
-        {
-            OnInteractionConfigUpdated?.Invoke(_interactions);
-        }
-
-        public void TrackingConfigWasUpdated()
-        {
-            OnTrackingConfigUpdated?.Invoke(_tracking);
-        }
+        public void PhysicalConfigWasUpdated() => OnPhysicalConfigUpdated?.Invoke(_physical);
+        public void InteractionConfigWasUpdated() => OnInteractionConfigUpdated?.Invoke(_interactions);
+        public void TrackingConfigWasUpdated() => OnTrackingConfigUpdated?.Invoke(_tracking);
+        
 
         public bool AreConfigsInGoodState()
         {

--- a/TF_Service_dotNet/TouchFree/Configuration/IConfigManager.cs
+++ b/TF_Service_dotNet/TouchFree/Configuration/IConfigManager.cs
@@ -12,6 +12,7 @@
         delegate void TrackingConfigEvent(TrackingConfig config = null);
         event InteractionConfigEvent OnInteractionConfigUpdated;
         event PhysicalConfigEvent OnPhysicalConfigUpdated;
+        event TrackingConfigEvent OnTrackingConfigSaved;
         event TrackingConfigEvent OnTrackingConfigUpdated;
         void PhysicalConfigWasUpdated();
         void InteractionConfigWasUpdated();

--- a/TF_Service_dotNet/TouchFree/Configuration/TrackingConfigFile.cs
+++ b/TF_Service_dotNet/TouchFree/Configuration/TrackingConfigFile.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Ultraleap.TouchFree.Library.Connections;
 
 namespace Ultraleap.TouchFree.Library.Configuration
 {
@@ -19,9 +20,17 @@ namespace Ultraleap.TouchFree.Library.Configuration
     [Serializable]
     public class MaskingData
     {
-        public float Lower = 0;
-        public float Upper = 0;
-        public float Right = 0;
-        public float Left = 0;
+        public double Lower = 0;
+        public double Upper = 0;
+        public double Right = 0;
+        public double Left = 0;
+
+        public static explicit operator MaskingData(ImageMaskData other) => new()
+        {
+            Left = other.left,
+            Lower = other.lower,
+            Right = other.right,
+            Upper = other.upper
+        };
     }
 }

--- a/TF_Service_dotNet/TouchFree/Configuration/TrackingConfigFile.cs
+++ b/TF_Service_dotNet/TouchFree/Configuration/TrackingConfigFile.cs
@@ -14,14 +14,6 @@ namespace Ultraleap.TouchFree.Library.Configuration
         public bool AllowImages = true;
         public bool CameraReversed = false;
         public bool AnalyticsEnabled = true;
-
-        public TrackingConfig()
-        {
-            Mask = new MaskingData();
-            AllowImages = true;
-            CameraReversed = false;
-            AnalyticsEnabled = true;
-        }
     }
 
     [Serializable]

--- a/TF_Service_dotNet/TouchFree/Connections/ClientConnection.cs
+++ b/TF_Service_dotNet/TouchFree/Connections/ClientConnection.cs
@@ -14,15 +14,8 @@ namespace Ultraleap.TouchFree.Library.Connections
 {
     public class ClientConnection : IClientConnection
     {
-        public WebSocket Socket
-        {
-            get
-            {
-                return socket;
-            }
-        }
+        public WebSocket Socket { get; }
 
-        private readonly WebSocket socket;
         private bool HandshakeCompleted;
         private readonly IEnumerable<IMessageQueueHandler> messageQueueHandlers;
         private readonly IClientConnectionManager clientMgr;
@@ -30,7 +23,7 @@ namespace Ultraleap.TouchFree.Library.Connections
 
         public ClientConnection(WebSocket _socket, IEnumerable<IMessageQueueHandler> _messageQueueHandlers, IClientConnectionManager _clientMgr, IConfigManager _configManager)
         {
-            socket = _socket;
+            Socket = _socket;
             messageQueueHandlers = _messageQueueHandlers;
             clientMgr = _clientMgr;
             configManager = _configManager;
@@ -70,8 +63,7 @@ namespace Ultraleap.TouchFree.Library.Connections
             SendResponse(_response, ActionCode.HAND_PRESENCE_EVENT);
         }
 
-
-        public void SendHandshakeResponse(ResponseToClient _response)
+        private void SendHandshakeResponse(ResponseToClient _response)
         {
             SendResponse(_response, ActionCode.VERSION_HANDSHAKE_RESPONSE);
         }
@@ -95,7 +87,7 @@ namespace Ultraleap.TouchFree.Library.Connections
             this.SendHandPresenceEvent(clientMgr.MissedHandPresenceEvent);
         }
 
-        public Compatibility GetVersionCompability(string _clientVersion, Version _coreVersion)
+        public static Compatibility GetVersionCompability(string _clientVersion, Version _coreVersion)
         {
             Version clientVersionParsed = new Version(_clientVersion);
 
@@ -164,7 +156,7 @@ namespace Ultraleap.TouchFree.Library.Connections
             }
         }
 
-        protected void ProcessHandshake(ActionCode action, string requestContent)
+        private void ProcessHandshake(ActionCode action, string requestContent)
         {
             JObject contentObj = JsonConvert.DeserializeObject<JObject>(requestContent);
             ResponseToClient response = new ResponseToClient("", "Success", "", requestContent);
@@ -224,7 +216,6 @@ namespace Ultraleap.TouchFree.Library.Connections
 
             response.status = "Failure";
             SendHandshakeResponse(response);
-            return;
         }
 
         private void SendAndHandleHandshakeFailure(string message, ResponseToClient response)

--- a/TF_Service_dotNet/TouchFree/Connections/DiagnosticApiTypes.cs
+++ b/TF_Service_dotNet/TouchFree/Connections/DiagnosticApiTypes.cs
@@ -57,6 +57,14 @@
         public double right;
         public double left;
         public uint device_id;
+
+        public static explicit operator ImageMaskData(Configuration.MaskingData other) => new()
+        {
+            left = other.Left,
+            right = other.Right,
+            upper = other.Upper,
+            lower = other.Lower
+        };
     }
 
     struct DiagnosticDevice

--- a/TF_Service_dotNet/TouchFree/Connections/ITrackingConnectionManager.cs
+++ b/TF_Service_dotNet/TouchFree/Connections/ITrackingConnectionManager.cs
@@ -1,12 +1,16 @@
-﻿namespace Ultraleap.TouchFree.Library.Connections
+﻿using System;
+
+namespace Ultraleap.TouchFree.Library.Connections
 {
     public interface ITrackingConnectionManager
     {
         TrackingMode CurrentTrackingMode { get; }
-        Leap.Controller controller { get; }
+        Leap.IController Controller { get; }
         void Connect();
         void Disconnect();
         void SetImagesState(bool enabled);
         bool ShouldSendHandData { get; }
+        TrackingServiceState TrackingServiceState { get; }
+        event Action<TrackingServiceState> ServiceStatusChange;
     }
 }

--- a/TF_Service_dotNet/TouchFree/Connections/ITrackingDiagnosticAPI.cs
+++ b/TF_Service_dotNet/TouchFree/Connections/ITrackingDiagnosticAPI.cs
@@ -1,39 +1,33 @@
 ﻿using System;
-using Ultraleap.TouchFree.Library.Configuration;
 
 namespace Ultraleap.TouchFree.Library.Connections
 {
     public interface ITrackingDiagnosticApi
     {
-        public event Action<ImageMaskData?, string> OnMaskingResponse;
-        public event Action<bool?, string> OnAnalyticsResponse;
-        public event Action<bool?, string> OnAllowImagesResponse;
-        public event Action<bool?, string> OnCameraOrientationResponse;
+        public event Action<Result<ImageMaskData>> OnMaskingResponse;
+        public event Action<Result<bool>> OnAnalyticsResponse;
+        public event Action<Result<bool>> OnAllowImagesResponse;
+        public event Action<Result<bool>> OnCameraOrientationResponse;
 
         public event Action OnTrackingApiVersionResponse;
         public event Action OnTrackingServerInfoResponse;
         public event Action OnTrackingDeviceInfoResponse;
 
-        void GetAnalyticsMode();
-        void SetAnalyticsMode(bool enabled);
+        void RequestGetAnalyticsMode();
+        void RequestSetAnalyticsMode(bool enabled);
 
-        void GetAllowImages();
-        void SetAllowImages(bool enabled);
+        void RequestGetAllowImages();
+        void RequestSetAllowImages(bool enabled);
 
-        void GetImageMask();
-        void SetMasking(float _left, float _right, float _top, float _bottom);
+        void RequestGetImageMask();
+        void RequestSetImageMask(double _left, double _right, double _top, double _bottom);
 
-        void GetCameraOrientation();
-        void SetCameraOrientation(bool reverseOrientation);
+        void RequestGetCameraOrientation();
+        void RequestSetCameraOrientation(bool reverseOrientation);
 
-        void GetDeviceInfo();
-        void GetDevices();
-        void GetServerInfo();
-        void GetVersion();
-
-        void HandleDiagnosticAPIVersion(string _version);
-        void Request(object payload);
-
-        void TriggerUpdatingTrackingConfiguration();
+        void RequestGetDeviceInfo();
+        void RequestGetDevices();
+        void RequestGetServerInfo();
+        void RequestGetVersion();
     }
 }

--- a/TF_Service_dotNet/TouchFree/Connections/MessageQueues/MessageQueueHandler.cs
+++ b/TF_Service_dotNet/TouchFree/Connections/MessageQueues/MessageQueueHandler.cs
@@ -39,7 +39,7 @@ namespace Ultraleap.TouchFree.Library.Connections.MessageQueues
             CheckQueue();
         }
 
-        protected void CheckQueue()
+        private void CheckQueue()
         {
             IncomingRequest content;
             if (queue.TryPeek(out content))

--- a/TF_Service_dotNet/TouchFree/Connections/MessageQueues/ServiceStatusQueueHandler.cs
+++ b/TF_Service_dotNet/TouchFree/Connections/MessageQueues/ServiceStatusQueueHandler.cs
@@ -1,5 +1,4 @@
-﻿using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+﻿using Newtonsoft.Json.Linq;
 using Ultraleap.TouchFree.Library.Configuration;
 
 namespace Ultraleap.TouchFree.Library.Connections.MessageQueues
@@ -23,15 +22,9 @@ namespace Ultraleap.TouchFree.Library.Connections.MessageQueues
 
         protected override void Handle(IncomingRequest _request, JObject _contentObject, string requestId)
         {
-            TrackingServiceState trackingServiceState = TrackingServiceState.UNAVAILABLE;
-            if (handManager.TrackingServiceConnected())
-            {
-                trackingServiceState = handManager.CameraConnected() ? TrackingServiceState.CONNECTED : TrackingServiceState.NO_CAMERA;
-            }
-
-            ServiceStatus currentConfig = new ServiceStatus(
+            var currentConfig = new ServiceStatus(
                 requestId,
-                trackingServiceState,
+                handManager.ConnectionManager.TrackingServiceState,
                 configManager.ErrorLoadingConfigFiles ? ConfigurationState.ERRORED : ConfigurationState.LOADED);
 
 

--- a/TF_Service_dotNet/TouchFree/Connections/MessageQueues/TrackingApiChangeQueueHandler.cs
+++ b/TF_Service_dotNet/TouchFree/Connections/MessageQueues/TrackingApiChangeQueueHandler.cs
@@ -135,7 +135,10 @@ namespace Ultraleap.TouchFree.Library.Connections.MessageQueues
                 trackingFromFile.AnalyticsEnabled = analyticsEnable;
             }
 
-            TrackingConfigFile.SaveConfig(trackingFromFile);
+            if (needsAnalytics || needsImages || needsMask || needsOrientation)
+            {
+                TrackingConfigFile.SaveConfig(trackingFromFile);
+            }
         }
 
         void CheckDApiResponse()

--- a/TF_Service_dotNet/TouchFree/Connections/MessageQueues/TrackingApiChangeQueueHandler.cs
+++ b/TF_Service_dotNet/TouchFree/Connections/MessageQueues/TrackingApiChangeQueueHandler.cs
@@ -1,5 +1,4 @@
-﻿using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+﻿using Newtonsoft.Json.Linq;
 using System;
 using Ultraleap.TouchFree.Library.Configuration;
 
@@ -82,10 +81,10 @@ namespace Ultraleap.TouchFree.Library.Connections.MessageQueues
             trackingApiResponse = new TrackingResponse(_request.requestId, _request.content, true, true, true, true, true);
             responseOriginTime = DateTimeOffset.Now.ToUnixTimeMilliseconds();
 
-            diagnosticApi.GetAllowImages();
-            diagnosticApi.GetImageMask();
-            diagnosticApi.GetCameraOrientation();
-            diagnosticApi.GetAnalyticsMode();
+            diagnosticApi.RequestGetAllowImages();
+            diagnosticApi.RequestGetImageMask();
+            diagnosticApi.RequestGetCameraOrientation();
+            diagnosticApi.RequestGetAnalyticsMode();
         }
 
         void HandleSetTrackingStateRequest(JObject contentObj, IncomingRequest _request)
@@ -108,7 +107,7 @@ namespace Ultraleap.TouchFree.Library.Connections.MessageQueues
             if (needsMask)
             {
                 var mask = maskToken!.ToObject<MaskingData>();
-                diagnosticApi.SetMasking(mask.left, mask.right, mask.upper, mask.lower);
+                diagnosticApi.RequestSetImageMask(mask.left, mask.right, mask.upper, mask.lower);
                 trackingFromFile.Mask.Left = mask.left;
                 trackingFromFile.Mask.Right = mask.right;
                 trackingFromFile.Mask.Upper = mask.upper;
@@ -118,21 +117,21 @@ namespace Ultraleap.TouchFree.Library.Connections.MessageQueues
             if (needsImages)
             {
                 var allowImages = allowImagesToken!.ToObject<bool>();
-                diagnosticApi.SetAllowImages(allowImages);
+                diagnosticApi.RequestSetAllowImages(allowImages);
                 trackingFromFile.AllowImages = allowImages;
             }
 
             if (needsOrientation)
             {
                 var reversed = cameraReversedToken!.ToObject<bool>();
-                diagnosticApi.SetCameraOrientation(reversed);
+                diagnosticApi.RequestSetCameraOrientation(reversed);
                 trackingFromFile.CameraReversed = reversed;
             }
 
             if (needsAnalytics)
             {
                 var analyticsEnable = analyticsEnabledToken!.ToObject<bool>();
-                diagnosticApi.SetAnalyticsMode(analyticsEnable);
+                diagnosticApi.RequestSetAnalyticsMode(analyticsEnable);
                 trackingFromFile.AnalyticsEnabled = analyticsEnable;
             }
 
@@ -192,83 +191,63 @@ namespace Ultraleap.TouchFree.Library.Connections.MessageQueues
             return (!_response.needsMask && !_response.needsImages && !_response.needsOrientation && !_response.needsAnalytics);
         }
 
-        public void OnMasking(ImageMaskData? _mask, string _message)
+        private void OnMasking(Result<ImageMaskData> _imageMask)
         {
             if (trackingApiResponse.HasValue)
             {
                 var response = trackingApiResponse.Value;
 
-                if (_mask.HasValue)
+                response.state.mask = _imageMask.Match(mask =>
                 {
-                    var mask = _mask.Value;
-                    var convertedMask = new MaskingData((float)mask.lower, (float)mask.upper, (float)mask.right, (float)mask.left);
-                    response.state.mask = new SuccessWrapper<MaskingData?>(true, _message, convertedMask);
-                }
-                else
-                {
-                    response.state.mask = new SuccessWrapper<MaskingData?>(false, _message, null);
-                }
+                    var convertedMask = new MaskingData((float)mask.lower, (float)mask.upper, (float)mask.right,
+                        (float)mask.left);
+                    return new SuccessWrapper<MaskingData?>(true, "Image Mask State", convertedMask);
+                }, error => new SuccessWrapper<MaskingData?>(false, error, null));
 
                 response.needsMask = false;
                 trackingApiResponse = response;
             }
         }
 
-        public void OnAllowImages(bool? _allowImages, string _message)
+        private void OnAllowImages(Result<bool> _allowImages)
         {
             if (trackingApiResponse.HasValue)
             {
                 var response = trackingApiResponse.Value;
 
-                if (_allowImages.HasValue)
-                {
-                    response.state.allowImages = new SuccessWrapper<bool?>(true, _message, _allowImages.Value);
-                }
-                else
-                {
-                    response.state.allowImages = new SuccessWrapper<bool?>(false, _message, null);
-                }
+                response.state.allowImages =
+                    _allowImages.Match(value => new SuccessWrapper<bool?>(true, "AllowImages State", value),
+                        error => new SuccessWrapper<bool?>(false, error, null));
 
                 response.needsImages = false;
                 trackingApiResponse = response;
             }
         }
 
-        public void OnCameraOrientation(bool? _cameraReversed, string _message)
+        private void OnCameraOrientation(Result<bool> _cameraReversed)
         {
             if (trackingApiResponse.HasValue)
             {
                 var response = trackingApiResponse.Value;
 
-                if (_cameraReversed.HasValue)
-                {
-                    response.state.cameraReversed = new SuccessWrapper<bool?>(true, _message, _cameraReversed.Value);
-                }
-                else
-                {
-                    response.state.cameraReversed = new SuccessWrapper<bool?>(false, _message, null);
-                }
+                response.state.cameraReversed = _cameraReversed.Match(
+                    value => new SuccessWrapper<bool?>(true, "CameraOrientation State", value),
+                    error => new SuccessWrapper<bool?>(false, error, null));
 
                 response.needsOrientation = false;
                 trackingApiResponse = response;
             }
         }
 
-        public void OnAnalytics(bool? _analytics, string _message)
+        private void OnAnalytics(Result<bool> _analytics)
         {
             if (trackingApiResponse.HasValue)
             {
                 var response = trackingApiResponse.Value;
 
-
-                if (_analytics.HasValue)
-                {
-                    response.state.analyticsEnabled = new SuccessWrapper<bool?>(true, _message, _analytics.Value);
-                }
-                else
-                {
-                    response.state.analyticsEnabled = new SuccessWrapper<bool?>(false, _message, null);
-                }
+                response.state.analyticsEnabled = _analytics.Match(
+                    value => new SuccessWrapper<bool?>(true, "Analytics State", value),
+                    error => new SuccessWrapper<bool?>(false, error, null));
 
                 response.needsAnalytics = false;
                 trackingApiResponse = response;

--- a/TF_Service_dotNet/TouchFree/Connections/TrackingConnectionManager.cs
+++ b/TF_Service_dotNet/TouchFree/Connections/TrackingConnectionManager.cs
@@ -9,7 +9,6 @@ namespace Ultraleap.TouchFree.Library.Connections
     {
         public IController Controller { get; }
 
-        private readonly ITrackingDiagnosticApi diagnosticApi;
         private readonly IConfigManager configManager;
 
         private const int maximumWaitTimeSeconds = 30;
@@ -30,9 +29,8 @@ namespace Ultraleap.TouchFree.Library.Connections
         
         public event Action<TrackingServiceState> ServiceStatusChange;
 
-        public TrackingConnectionManager(IConfigManager _configManager, ITrackingDiagnosticApi _diagnosticApi)
+        public TrackingConnectionManager(IConfigManager _configManager)
         {
-            diagnosticApi = _diagnosticApi;
             configManager = _configManager;
             Controller = new Controller();
             Controller.Connect += ControllerOnConnect;
@@ -49,7 +47,6 @@ namespace Ultraleap.TouchFree.Library.Connections
             // More than 1 device connected now, ignore this event as we only care about at least one device connection
             if (Controller.Devices.Count > 1) return;
             ServiceStatusChange?.Invoke(TrackingServiceState.CONNECTED);
-            diagnosticApi.TriggerUpdatingTrackingConfiguration();
         }
 
         private void ControllerOnDeviceLost(object sender, DeviceEventArgs e)

--- a/TF_Service_dotNet/TouchFree/Connections/TrackingConnectionManager.cs
+++ b/TF_Service_dotNet/TouchFree/Connections/TrackingConnectionManager.cs
@@ -6,7 +6,7 @@ namespace Ultraleap.TouchFree.Library.Connections
 {
     public class TrackingConnectionManager : ITrackingConnectionManager
     {
-        public Leap.Controller controller { get; private set; }
+        public Leap.Controller controller { get; }
 
         private readonly ITrackingDiagnosticApi diagnosticApi;
         private readonly IConfigManager configManager;
@@ -16,13 +16,7 @@ namespace Ultraleap.TouchFree.Library.Connections
         private bool ShouldConnect = false;
 
         public bool ShouldSendHandData { get; private set; }
-
-        private TrackingMode currentTrackingMode;
-
-        public TrackingMode CurrentTrackingMode
-        {
-            get { return currentTrackingMode; }
-        }
+        public TrackingMode CurrentTrackingMode { get; private set; }
 
         public TrackingConnectionManager(IConfigManager _configManager, ITrackingDiagnosticApi _diagnosticApi)
         {
@@ -156,7 +150,7 @@ namespace Ultraleap.TouchFree.Library.Connections
         {
             TouchFreeLog.WriteLine($"Requesting {_mode} tracking mode");
 
-            currentTrackingMode = _mode;
+            CurrentTrackingMode = _mode;
 
             switch (_mode)
             {

--- a/TF_Service_dotNet/TouchFree/Connections/TrackingConnectionManager.cs
+++ b/TF_Service_dotNet/TouchFree/Connections/TrackingConnectionManager.cs
@@ -1,12 +1,13 @@
 ﻿using System;
 using System.Threading.Tasks;
+using Leap;
 using Ultraleap.TouchFree.Library.Configuration;
 
 namespace Ultraleap.TouchFree.Library.Connections
 {
     public class TrackingConnectionManager : ITrackingConnectionManager
     {
-        public Leap.Controller controller { get; }
+        public IController Controller { get; }
 
         private readonly ITrackingDiagnosticApi diagnosticApi;
         private readonly IConfigManager configManager;
@@ -18,18 +19,44 @@ namespace Ultraleap.TouchFree.Library.Connections
         public bool ShouldSendHandData { get; private set; }
         public TrackingMode CurrentTrackingMode { get; private set; }
 
+        public TrackingServiceState TrackingServiceState =>
+            (Controller.IsServiceConnected, Controller.IsConnected) switch
+            {
+                (true, true) => TrackingServiceState.CONNECTED,
+                (true, false) => TrackingServiceState.NO_CAMERA,
+                // (false, true) => ???, Weird state that's currently impossible if you inspect the implementation of IsConnected
+                _ => TrackingServiceState.UNAVAILABLE
+            };
+        
+        public event Action<TrackingServiceState> ServiceStatusChange;
+
         public TrackingConnectionManager(IConfigManager _configManager, ITrackingDiagnosticApi _diagnosticApi)
         {
             diagnosticApi = _diagnosticApi;
             configManager = _configManager;
-            controller = new Leap.Controller();
-            controller.Connect += Controller_Connect;
-            controller.Disconnect += Controller_Disconnect;
+            Controller = new Controller();
+            Controller.Connect += ControllerOnConnect;
+            Controller.Disconnect += ControllerOnDisconnect;
+            Controller.Device += ControllerOnDevice;
+            Controller.DeviceLost += ControllerOnDeviceLost;
             UpdateTrackingMode(_configManager.PhysicalConfig);
             _configManager.OnPhysicalConfigUpdated += UpdateTrackingMode;
-            controller.StopConnection();
+            Controller.StopConnection();
+        }
 
-            controller.Device += Controller_CameraConnected;
+        private void ControllerOnDevice(object sender, DeviceEventArgs e)
+        {
+            // More than 1 device connected now, ignore this event as we only care about at least one device connection
+            if (Controller.Devices.Count > 1) return;
+            ServiceStatusChange?.Invoke(TrackingServiceState.CONNECTED);
+            diagnosticApi.TriggerUpdatingTrackingConfiguration();
+        }
+
+        private void ControllerOnDeviceLost(object sender, DeviceEventArgs e)
+        {
+            // We still have at least one device, ignore this event as we only care about at least one device connection
+            if (Controller.Devices.Count >= 1) return;
+            ServiceStatusChange?.Invoke(TrackingServiceState.NO_CAMERA);
         }
 
         public void Connect()
@@ -41,20 +68,17 @@ namespace Ultraleap.TouchFree.Library.Connections
         public void Disconnect()
         {
             ShouldConnect = false;
-            if (controller.IsServiceConnected)
+            if (Controller.IsServiceConnected)
             {
-                controller.StopConnection();
+                Controller.StopConnection();
             }
         }
 
-        public void Controller_CameraConnected(object sender, Leap.DeviceEventArgs e)
+        private void ControllerOnConnect(object sender, ConnectionEventArgs e)
         {
-            diagnosticApi.TriggerUpdatingTrackingConfiguration();
-        }
-
-        private void Controller_Connect(object sender, Leap.ConnectionEventArgs e)
-        {
+            
             UpdateTrackingMode(configManager.PhysicalConfig);
+            ServiceStatusChange?.Invoke(TrackingServiceState.NO_CAMERA);
 
             CheckTrackingModeIsCorrectAfterDelay();
         }
@@ -62,12 +86,12 @@ namespace Ultraleap.TouchFree.Library.Connections
         private async void CheckTrackingModeIsCorrectAfterDelay()
         {
             await Task.Delay(5000);
-            if (controller.IsServiceConnected)
+            if (Controller.IsServiceConnected)
             {
                 var trackingMode = GetTrackingModeFromConfig(configManager.PhysicalConfig);
 
-                var inScreenTop = controller.IsPolicySet(Leap.Controller.PolicyFlag.POLICY_OPTIMIZE_SCREENTOP);
-                var inHmd = controller.IsPolicySet(Leap.Controller.PolicyFlag.POLICY_OPTIMIZE_HMD);
+                var inScreenTop = Controller.IsPolicySet(Leap.Controller.PolicyFlag.POLICY_OPTIMIZE_SCREENTOP);
+                var inHmd = Controller.IsPolicySet(Leap.Controller.PolicyFlag.POLICY_OPTIMIZE_HMD);
 
                 if (TrackingModeIsIncorrect(trackingMode, inScreenTop, inHmd))
                 {
@@ -83,8 +107,9 @@ namespace Ultraleap.TouchFree.Library.Connections
                 (trackingMode == TrackingMode.DESKTOP && (inScreenTop || inHmd));
         }
 
-        private void Controller_Disconnect(object sender, Leap.ConnectionLostEventArgs e)
+        private void ControllerOnDisconnect(object sender, Leap.ConnectionLostEventArgs e)
         {
+            ServiceStatusChange?.Invoke(TrackingServiceState.UNAVAILABLE);
             if (ShouldConnect)
             {
                 CheckConnectionAndRetryOnFailure(true);
@@ -97,13 +122,13 @@ namespace Ultraleap.TouchFree.Library.Connections
 
             if (includeInitialDelay)
             {
-                await Task.Delay(1000 * waitTimeSeconds);
+                await Task.Delay(1000);
                 waitTimeSeconds = IncreaseWaitTimeSeconds(waitTimeSeconds);
             }
 
-            while (!controller.IsServiceConnected && ShouldConnect)
+            while (!Controller.IsServiceConnected && ShouldConnect)
             {
-                controller.StartConnection();
+                Controller.StartConnection();
 
                 await Task.Delay(1000 * waitTimeSeconds);
                 waitTimeSeconds = IncreaseWaitTimeSeconds(waitTimeSeconds);
@@ -121,12 +146,12 @@ namespace Ultraleap.TouchFree.Library.Connections
             return updatedWaitTime > maximumWaitTimeSeconds ? maximumWaitTimeSeconds : updatedWaitTime;
         }
 
-        public void UpdateTrackingMode(PhysicalConfigInternal _config)
+        private void UpdateTrackingMode(PhysicalConfigInternal _config)
         {
             SetTrackingMode(GetTrackingModeFromConfig(_config));
         }
 
-        TrackingMode GetTrackingModeFromConfig(PhysicalConfigInternal _config)
+        private static TrackingMode GetTrackingModeFromConfig(PhysicalConfigInternal _config)
         {
             // leap is looking down
             if (Math.Abs(_config.LeapRotationD.Z) > 90f)
@@ -146,7 +171,7 @@ namespace Ultraleap.TouchFree.Library.Connections
             }
         }
 
-        void SetTrackingMode(TrackingMode _mode)
+        private void SetTrackingMode(TrackingMode _mode)
         {
             TouchFreeLog.WriteLine($"Requesting {_mode} tracking mode");
 
@@ -155,16 +180,16 @@ namespace Ultraleap.TouchFree.Library.Connections
             switch (_mode)
             {
                 case TrackingMode.DESKTOP:
-                    controller.ClearPolicy(Leap.Controller.PolicyFlag.POLICY_OPTIMIZE_SCREENTOP);
-                    controller.ClearPolicy(Leap.Controller.PolicyFlag.POLICY_OPTIMIZE_HMD);
+                    Controller.ClearPolicy(Leap.Controller.PolicyFlag.POLICY_OPTIMIZE_SCREENTOP);
+                    Controller.ClearPolicy(Leap.Controller.PolicyFlag.POLICY_OPTIMIZE_HMD);
                     break;
                 case TrackingMode.HMD:
-                    controller.ClearPolicy(Leap.Controller.PolicyFlag.POLICY_OPTIMIZE_SCREENTOP);
-                    controller.SetPolicy(Leap.Controller.PolicyFlag.POLICY_OPTIMIZE_HMD);
+                    Controller.ClearPolicy(Leap.Controller.PolicyFlag.POLICY_OPTIMIZE_SCREENTOP);
+                    Controller.SetPolicy(Leap.Controller.PolicyFlag.POLICY_OPTIMIZE_HMD);
                     break;
                 case TrackingMode.SCREENTOP:
-                    controller.SetPolicy(Leap.Controller.PolicyFlag.POLICY_OPTIMIZE_SCREENTOP);
-                    controller.ClearPolicy(Leap.Controller.PolicyFlag.POLICY_OPTIMIZE_HMD);
+                    Controller.SetPolicy(Leap.Controller.PolicyFlag.POLICY_OPTIMIZE_SCREENTOP);
+                    Controller.ClearPolicy(Leap.Controller.PolicyFlag.POLICY_OPTIMIZE_HMD);
                     break;
             }
         }
@@ -174,11 +199,11 @@ namespace Ultraleap.TouchFree.Library.Connections
             ShouldSendHandData = enabled;
             if (enabled)
             {
-                controller.SetPolicy(Leap.Controller.PolicyFlag.POLICY_IMAGES);
+                Controller.SetPolicy(Leap.Controller.PolicyFlag.POLICY_IMAGES);
             }
             else
             {
-                controller.ClearPolicy(Leap.Controller.PolicyFlag.POLICY_IMAGES);
+                Controller.ClearPolicy(Leap.Controller.PolicyFlag.POLICY_IMAGES);
             }
         }
     }

--- a/TF_Service_dotNet/TouchFree/Connections/TrackingDiagnosticAPI.cs
+++ b/TF_Service_dotNet/TouchFree/Connections/TrackingDiagnosticAPI.cs
@@ -30,6 +30,10 @@ namespace Ultraleap.TouchFree.Library.Connections
         public event Action OnTrackingServerInfoResponse;
         public event Action OnTrackingDeviceInfoResponse;
 
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <typeparam name="TData"></typeparam>
         private class ConfigurationVariable<TData>
         {
             private readonly Action<ConfigurationVariable<TData>> _onSet;
@@ -171,7 +175,19 @@ namespace Ultraleap.TouchFree.Library.Connections
                 // If nothing changed, we don't need to save - this is to avoid infinite looping caused by events
                 if (configChanged)
                 {
-                    TrackingConfigFile.SaveConfig(new TrackingConfig());
+                    TrackingConfigFile.SaveConfig(new TrackingConfig
+                    {
+                        Mask =
+                        {
+                            Left = (float)maskingData.Value.left,
+                            Right = (float)maskingData.Value.right,
+                            Lower = (float)maskingData.Value.lower,
+                            Upper = (float)maskingData.Value.upper
+                        },
+                        AllowImages = allowImages.Value,
+                        AnalyticsEnabled = analyticsEnabled.Value,
+                        CameraReversed = cameraReversed.Value
+                    });
                 }
             }
         }

--- a/TF_Service_dotNet/TouchFree/Connections/TrackingDiagnosticAPI.cs
+++ b/TF_Service_dotNet/TouchFree/Connections/TrackingDiagnosticAPI.cs
@@ -100,7 +100,7 @@ namespace Ultraleap.TouchFree.Library.Connections
                 RequestSetImageMask(config.Mask.Left, config.Mask.Right, config.Mask.Upper, config.Mask.Lower);
             }
             void ControllerOnDevice(object sender, DeviceEventArgs e) => RequestGetDevices(); // Get devices response will update the connected device and refresh tracking config
-            void ControllerOnDeviceLost(object sender, DeviceEventArgs e) => connectedDeviceID = null;
+            void ControllerOnDeviceLost(object sender, DeviceEventArgs e) => RequestGetDevices(); // Works even when no device is connected
 
             _configManager.OnTrackingConfigUpdated += SetTrackingConfigurationOnDevice;
             _trackingConnectionManager.Controller.Device += ControllerOnDevice;

--- a/TF_Service_dotNet/TouchFree/Connections/TrackingDiagnosticAPI.cs
+++ b/TF_Service_dotNet/TouchFree/Connections/TrackingDiagnosticAPI.cs
@@ -30,10 +30,7 @@ namespace Ultraleap.TouchFree.Library.Connections
         public event Action OnTrackingServerInfoResponse;
         public event Action OnTrackingDeviceInfoResponse;
 
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <typeparam name="TData"></typeparam>
+        // Represents a variable that will be "initialized" once set at least once after construction
         private class ConfigurationVariable<TData>
         {
             private readonly Action<ConfigurationVariable<TData>> _onSet;
@@ -58,9 +55,9 @@ namespace Ultraleap.TouchFree.Library.Connections
 
             // Variable is not considered initialized until it has been set externally from the constructor.
             // Scenarios this is expected to happen:
-            // a. Loaded from an existing config
-            // b. Loaded from connected device if there is no existing config
-            // c. Set by an incoming request
+            // a. Set by an incoming request
+            // b. Loaded from an existing config
+            // c. Loaded from connected device if not initialized before connecting
             public bool Initialized { get; private set; }
 
             public void Match(Action<TData> initialized, Action uninitialized)

--- a/TF_Service_dotNet/TouchFree/HandManager.cs
+++ b/TF_Service_dotNet/TouchFree/HandManager.cs
@@ -132,15 +132,9 @@ namespace Ultraleap.TouchFree.Library
             }
         }
 
-        public bool TrackingServiceConnected()
-        {
-            return trackingProvider?.controller?.IsServiceConnected ?? false;
-        }
+        public bool IsTrackingServiceConnected() => trackingProvider?.controller?.IsServiceConnected ?? false;
 
-        public bool CameraConnected()
-        {
-            return trackingProvider?.controller?.Devices?.ActiveDevice != null;
-        }
+        public bool IsCameraConnected() => trackingProvider?.controller?.Devices?.ActiveDevice != null;
 
         public void UpdateTrackingTransform(PhysicalConfigInternal _config)
         {

--- a/TF_Service_dotNet/TouchFree/HandManager.cs
+++ b/TF_Service_dotNet/TouchFree/HandManager.cs
@@ -82,7 +82,7 @@ namespace Ultraleap.TouchFree.Library
             // Therefore, we must convert to the real values before using them.
             // If bottom mounted, the X rotation should be negative if tilted towards the screen so we must negate the X rotation in this instance.
             var isTopMounted = _config.LeapRotationD.Z is > 179.9f and < 180.1f;
-            var xAngleDegree = isTopMounted ? _config.LeapRotationD.X : -_config.LeapRotationD.X;
+            float xAngleDegree = isTopMounted ? _config.LeapRotationD.X : -_config.LeapRotationD.X;
 
             var quaternion = Quaternion.CreateFromYawPitchRoll(Utilities.DegreesToRadians(_config.LeapRotationD.Y),
                 Utilities.DegreesToRadians(xAngleDegree + _config.ScreenRotationD),

--- a/TF_Service_dotNet/TouchFree/HandManager.cs
+++ b/TF_Service_dotNet/TouchFree/HandManager.cs
@@ -15,21 +15,14 @@ namespace Ultraleap.TouchFree.Library
 
         // The PrimaryHand is the hand that appeared first. It does not change until tracking on it is lost.
         public Hand PrimaryHand { get; private set; }
-        public HandChirality primaryChirality;
+        private HandChirality primaryChirality;
 
         // The SecondaryHand is the second hand that appears. It may be promoted to the PrimaryHand if the
         // PrimaryHand is lost.
         public Hand SecondaryHand { get; private set; }
-        public HandChirality secondaryChirality;
+        private HandChirality secondaryChirality;
 
-        public List<Leap.Vector> RawHandPositions
-        {
-            get
-            {
-                return _handPositions;
-            }
-        }
-        private List<Leap.Vector> _handPositions;
+        public List<Leap.Vector> RawHandPositions { get; private set; }
 
         public event Action HandFound;
         public event Action HandsLost;
@@ -45,54 +38,22 @@ namespace Ultraleap.TouchFree.Library
         private Vector3? lastPrimaryLocation;
         private Vector3? lastSecondaryLocation;
 
-        public Leap.Image.CameraType HandRenderLens { private get; set; } = Image.CameraType.LEFT;
+        public Image.CameraType HandRenderLens { private get; set; } = Image.CameraType.LEFT;
 
-        bool PrimaryIsLeft => PrimaryHand != null && PrimaryHand.IsLeft;
-        bool PrimaryIsRight => PrimaryHand != null && !PrimaryHand.IsLeft;
-        bool SecondaryIsLeft => SecondaryHand != null && SecondaryHand.IsLeft;
-        bool SecondaryIsRight => SecondaryHand != null && !SecondaryHand.IsLeft;
+        public Hand LeftHand =>
+            PrimaryHand is { IsLeft: true } ? PrimaryHand :
+            SecondaryHand is { IsLeft: true } ? SecondaryHand :
+            null;
 
-        public Hand LeftHand
-        {
-            get
-            {
-                if (PrimaryIsLeft)
-                {
-                    return PrimaryHand;
-                }
-                else if (SecondaryIsLeft)
-                {
-                    return SecondaryHand;
-                }
-                else
-                {
-                    return null;
-                }
-            }
-        }
-
-        public Hand RightHand
-        {
-            get
-            {
-                if (PrimaryIsRight)
-                {
-                    return PrimaryHand;
-                }
-                else if (SecondaryIsRight)
-                {
-                    return SecondaryHand;
-                }
-                else
-                {
-                    return null;
-                }
-            }
-        }
+        public Hand RightHand =>
+            PrimaryHand is { IsRight: true } ? PrimaryHand :
+            SecondaryHand is { IsRight: true } ? SecondaryHand :
+            null;
 
         private LeapTransform trackingTransform;
 
-        private ITrackingConnectionManager trackingProvider;
+        public ITrackingConnectionManager ConnectionManager { get; }
+
         private readonly IVirtualScreen virtualScreen;
         private readonly IConfigManager configManager;
 
@@ -102,49 +63,28 @@ namespace Ultraleap.TouchFree.Library
         public List<Hand> PreConversionRawHands { get; private set; }
         public bool RawHandsUpdated { get; private set; }
 
-        public void ConnectToTracking()
-        {
-            trackingProvider.Connect();
-        }
-
-        public void DisconnectFromTracking()
-        {
-            trackingProvider.Disconnect();
-        }
-
-        public HandManager(ITrackingConnectionManager _trackingManager, IConfigManager _configManager, IVirtualScreen _virtualScreen)
+        public HandManager(ITrackingConnectionManager _trackingConnectionManager, IConfigManager _configManager, IVirtualScreen _virtualScreen)
         {
             handsLastFrame = 0;
 
-            trackingProvider = _trackingManager;
+            ConnectionManager = _trackingConnectionManager;
             virtualScreen = _virtualScreen;
             configManager = _configManager;
-            if (trackingProvider != null)
-            {
-                trackingProvider.controller.FrameReady += Update;
-                trackingProvider.controller.ImageReady += UpdateRawHands;
-            }
-
-            if (_configManager != null)
-            {
-                _configManager.OnPhysicalConfigUpdated += UpdateTrackingTransform;
-                UpdateTrackingTransform(_configManager.PhysicalConfig);
-            }
+            ConnectionManager.Controller.FrameReady += Update;
+            ConnectionManager.Controller.ImageReady += UpdateRawHands;
+            _configManager.OnPhysicalConfigUpdated += UpdateTrackingTransform;
+            UpdateTrackingTransform(_configManager.PhysicalConfig);
         }
-
-        public bool IsTrackingServiceConnected() => trackingProvider?.controller?.IsServiceConnected ?? false;
-
-        public bool IsCameraConnected() => trackingProvider?.controller?.Devices?.ActiveDevice != null;
 
         public void UpdateTrackingTransform(PhysicalConfigInternal _config)
         {
             // To simplify the configuration values, positive X angles tilt the Leap towards the screen no matter how its mounted.
             // Therefore, we must convert to the real values before using them.
             // If bottom mounted, the X rotation should be negative if tilted towards the screen so we must negate the X rotation in this instance.
-            var isTopMounted = ((_config.LeapRotationD.Z > 179.9f) && (_config.LeapRotationD.Z < 180.1f));
-            float xAngleDegree = isTopMounted ? _config.LeapRotationD.X : -_config.LeapRotationD.X;
+            var isTopMounted = _config.LeapRotationD.Z is > 179.9f and < 180.1f;
+            var xAngleDegree = isTopMounted ? _config.LeapRotationD.X : -_config.LeapRotationD.X;
 
-            System.Numerics.Quaternion quaternion = System.Numerics.Quaternion.CreateFromYawPitchRoll(Utilities.DegreesToRadians(_config.LeapRotationD.Y),
+            var quaternion = Quaternion.CreateFromYawPitchRoll(Utilities.DegreesToRadians(_config.LeapRotationD.Y),
                 Utilities.DegreesToRadians(xAngleDegree + _config.ScreenRotationD),
                 Utilities.DegreesToRadians(_config.LeapRotationD.Z));
 
@@ -179,7 +119,7 @@ namespace Ultraleap.TouchFree.Library
             }
         }
 
-        private Vector3 LeapToCameraFrame(Leap.Vector leapVector, Leap.Image image)
+        private Vector3 LeapToCameraFrame(Leap.Vector leapVector, Image image)
         {
             var lensAdjustment = HandRenderLens == Image.CameraType.RIGHT ? -32.5f : 32.5f;
             var updatedVector = new Leap.Vector(leapVector.x + lensAdjustment, leapVector.y, leapVector.z);
@@ -190,30 +130,28 @@ namespace Ultraleap.TouchFree.Library
             return new Vector3(renderPosition.x / image.Width, renderPosition.y / image.Width, ray.z);
         }
 
-        public void UpdateRawHands(object sender, ImageEventArgs e)
+        private void UpdateRawHands(object sender, ImageEventArgs e)
         {
-            if (PreConversionRawHands != null && e.image != null && RawHandsUpdated)
+            if (PreConversionRawHands == null || e.image == null || !RawHandsUpdated) return;
+            RawHandsUpdated = false;
+            RawHands = new HandFrame
             {
-                RawHandsUpdated = false;
-                RawHands = new HandFrame()
+                Hands = PreConversionRawHands.Select(x => new RawHand()
                 {
-                    Hands = PreConversionRawHands.Select(x => new RawHand()
+                    CurrentPrimary = x.IsLeft == (primaryChirality == HandChirality.LEFT),
+                    Fingers = x.Fingers.Select(f => new RawFinger()
                     {
-                        CurrentPrimary = x.IsLeft == (primaryChirality == HandChirality.LEFT),
-                        Fingers = x.Fingers.Select(f => new RawFinger()
+                        Type = (FingerType)f.Type,
+                        Bones = f.bones.Select(b => new RawBone()
                         {
-                            Type = (FingerType)f.Type,
-                            Bones = f.bones.Select(b => new RawBone()
-                            {
-                                NextJoint = LeapToCameraFrame(b.NextJoint, e.image),
-                                PrevJoint = LeapToCameraFrame(b.PrevJoint, e.image)
-                            }).ToArray()
-                        }).ToArray(),
-                        WristPosition = LeapToCameraFrame(x.WristPosition, e.image),
-                        WristWidth = x.PalmWidth
-                    }).ToArray()
-                };
-            }
+                            NextJoint = LeapToCameraFrame(b.NextJoint, e.image),
+                            PrevJoint = LeapToCameraFrame(b.PrevJoint, e.image)
+                        }).ToArray()
+                    }).ToArray(),
+                    WristPosition = LeapToCameraFrame(x.WristPosition, e.image),
+                    WristWidth = x.PalmWidth
+                }).ToArray()
+            };
         }
 
         public void Update(object sender, FrameEventArgs e)
@@ -221,16 +159,17 @@ namespace Ultraleap.TouchFree.Library
             var currentFrame = e.frame;
             var handCount = currentFrame.Hands.Count;
 
-            if (handCount == 0 && handsLastFrame > 0)
+            switch (handCount)
             {
-                HandsLost?.Invoke();
-            }
-            else if (handCount > 0 && handsLastFrame == 0)
-            {
-                HandFound?.Invoke();
+                case 0 when handsLastFrame > 0:
+                    HandsLost?.Invoke();
+                    break;
+                case > 0 when handsLastFrame == 0:
+                    HandFound?.Invoke();
+                    break;
             }
 
-            _handPositions = currentFrame.Hands
+            RawHandPositions = currentFrame.Hands
                 .Select(x => x.Fingers?.SingleOrDefault(y => y.Type == Finger.FingerType.TYPE_INDEX)?.TipPosition)
                 .Where(x => x.HasValue)
                 .Select(x => x.Value)
@@ -294,9 +233,7 @@ namespace Ultraleap.TouchFree.Library
                     (HandActivityInSwapThreshold() ||
                      PrimaryHandIsOffScreen(primaryRelativeXScreenPosition, primaryRelativeYScreenPosition)))
                 {
-                    Hand oldPrimaryHand = PrimaryHand;
-                    PrimaryHand = SecondaryHand;
-                    SecondaryHand = oldPrimaryHand;
+                    (PrimaryHand, SecondaryHand) = (SecondaryHand, PrimaryHand);
                     primaryChirality = PrimaryHand.IsLeft ? HandChirality.LEFT : HandChirality.RIGHT;
                     secondaryChirality = SecondaryHand.IsLeft ? HandChirality.LEFT : HandChirality.RIGHT;
                 }
@@ -320,23 +257,15 @@ namespace Ultraleap.TouchFree.Library
             return PrimaryHandActivity < SecondaryHandActivityDefault && SecondaryHandActivity > PrimaryHandActivityDefault;
         }
 
-        private static bool PrimaryHandIsOffScreen(float _primaryRelativeXScreenPosition, float _primaryRelativeYScreenPosition)
-        {
-            return _primaryRelativeXScreenPosition > 1.4 ||
-                     _primaryRelativeXScreenPosition < -0.4 ||
-                     _primaryRelativeYScreenPosition > 1.4 ||
-                     _primaryRelativeYScreenPosition < -0.4;
-        }
+        private static bool PrimaryHandIsOffScreen(float _primaryRelativeXScreenPosition, float _primaryRelativeYScreenPosition) =>
+            _primaryRelativeXScreenPosition is > 1.4f or < -0.4f ||
+            _primaryRelativeYScreenPosition is > 1.4f or < -0.4f;
 
-        private static bool SecondaryHandIsOnScreen(float _secondaryRelativeXScreenPosition, float _secondaryRelativeYScreenPosition)
-        {
-            return _secondaryRelativeXScreenPosition < 1.4 &&
-                    _secondaryRelativeXScreenPosition > -0.4 &&
-                    _secondaryRelativeYScreenPosition < 1.4 &&
-                    _secondaryRelativeYScreenPosition > -0.4;
-        }
+        private static bool SecondaryHandIsOnScreen(float _secondaryRelativeXScreenPosition, float _secondaryRelativeYScreenPosition) =>
+            _secondaryRelativeXScreenPosition is < 1.4f and > -0.4f &&
+            _secondaryRelativeYScreenPosition is < 1.4f and > -0.4f;
 
-        void UpdateHandStatus(Hand _hand, Hand _left, Hand _right, HandType _handType)
+        private void UpdateHandStatus(Hand _hand, Hand _left, Hand _right, HandType _handType)
         {
             // We must use the cached HandChirality to ensure persistence
             HandChirality handChirality;
@@ -392,7 +321,7 @@ namespace Ultraleap.TouchFree.Library
             }
         }
 
-        void AssignHandAccordingToType(HandType _handType, Hand _hand)
+        private void AssignHandAccordingToType(HandType _handType, Hand _hand)
         {
             // Hand is still right
             if (_handType == HandType.PRIMARY)
@@ -405,7 +334,7 @@ namespace Ultraleap.TouchFree.Library
             }
         }
 
-        void AssignNewPrimary(Hand _left, Hand _right)
+        private void AssignNewPrimary(Hand _left, Hand _right)
         {
             // When assigning a new primary, we should force Secondary to be re-assigned too
             PrimaryHand = null;
@@ -423,7 +352,7 @@ namespace Ultraleap.TouchFree.Library
             }
         }
 
-        void AssignNewSecondary(Hand _left, Hand _right)
+        private void AssignNewSecondary(Hand _left, Hand _right)
         {
             SecondaryHand = null;
 
@@ -439,9 +368,6 @@ namespace Ultraleap.TouchFree.Library
             }
         }
 
-        public LeapTransform TrackingTransform()
-        {
-            return trackingTransform;
-        }
+        public LeapTransform TrackingTransform() => trackingTransform;
     }
 }

--- a/TF_Service_dotNet/TouchFree/IHandManager.cs
+++ b/TF_Service_dotNet/TouchFree/IHandManager.cs
@@ -1,10 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using Leap;
+using Ultraleap.TouchFree.Library.Connections;
 
 namespace Ultraleap.TouchFree.Library
 {
-    public delegate void ConnectionStatusEvent(bool oldIsConnected, bool newIsConnected);
     public interface IHandManager
     {
         Hand PrimaryHand { get; }
@@ -12,13 +12,9 @@ namespace Ultraleap.TouchFree.Library
         HandFrame RawHands { get; }
         List<Vector> RawHandPositions { get; }
         long Timestamp { get; }
-        void ConnectToTracking();
-        void DisconnectFromTracking();
-        bool IsTrackingServiceConnected();
-        bool IsCameraConnected();
         event Action HandFound;
         event Action HandsLost;
-        Leap.Image.CameraType HandRenderLens { set; }
-        event ConnectionStatusEvent Camera;
+        Image.CameraType HandRenderLens { set; }
+        ITrackingConnectionManager ConnectionManager { get; }
     }
 }

--- a/TF_Service_dotNet/TouchFree/IHandManager.cs
+++ b/TF_Service_dotNet/TouchFree/IHandManager.cs
@@ -4,6 +4,7 @@ using Leap;
 
 namespace Ultraleap.TouchFree.Library
 {
+    public delegate void ConnectionStatusEvent(bool oldIsConnected, bool newIsConnected);
     public interface IHandManager
     {
         Hand PrimaryHand { get; }
@@ -13,10 +14,11 @@ namespace Ultraleap.TouchFree.Library
         long Timestamp { get; }
         void ConnectToTracking();
         void DisconnectFromTracking();
-        bool TrackingServiceConnected();
-        bool CameraConnected();
+        bool IsTrackingServiceConnected();
+        bool IsCameraConnected();
         event Action HandFound;
         event Action HandsLost;
         Leap.Image.CameraType HandRenderLens { set; }
+        event ConnectionStatusEvent Camera;
     }
 }

--- a/TF_Service_dotNet/TouchFree/Plugins/LeapC/LeapCSharp/IController.cs
+++ b/TF_Service_dotNet/TouchFree/Plugins/LeapC/LeapCSharp/IController.cs
@@ -40,5 +40,10 @@ namespace Leap {
     event EventHandler<ImageEventArgs> ImageReady;
     event EventHandler<PointMappingChangeEventArgs> PointMappingChange;
     event EventHandler<HeadPoseEventArgs> HeadPoseChange;
+    
+    // Note: Added by Craig 23/8 as they were missing from interface
+    void StartConnection();
+    void StopConnection();
+    bool IsServiceConnected { get; }
   }
 }

--- a/TF_Service_dotNet/TouchFree/Result.cs
+++ b/TF_Service_dotNet/TouchFree/Result.cs
@@ -1,0 +1,76 @@
+﻿using System;
+
+namespace Ultraleap.TouchFree.Library;
+
+/// <summary>
+/// Result that can contain a value or an error
+/// </summary>
+/// <typeparam name="T">Type of contained value</typeparam>
+public abstract record Result<T>
+{
+    /// <summary>
+    /// Type that represents a contained value
+    /// </summary>
+    public record Some(T Value) : Result<T>
+    {
+        public static implicit operator Some(T value) => new(value);
+    }
+
+    /// <summary>
+    /// Type that represents an error
+    /// </summary>
+    public record Error(string ErrorValue) : Result<T>
+    {
+        public static implicit operator Error(string error) => new(error);
+    }
+    
+    public static implicit operator Result<T>(T value) => new Some(value);
+    public static implicit operator Result<T>(string error) => new Error(error);
+
+    public bool IsSuccess => !IsError;
+    public bool HasValue => this is Some;
+    public bool IsError => this is Error;
+        
+    public bool TryGetValue(out T value)
+    {
+        if (this is not Some)
+        {
+            value = default;
+            return false;
+        }
+
+        value = ((Some)this).Value;
+        return true;
+    }
+
+    public bool TryGetError(out string error)
+    {
+        if (this is not Error)
+        {
+            error = default;
+            return false;
+        }
+
+        error = ((Error)this).ErrorValue;
+        return true;
+    }
+
+    public bool GetValueOrError(out T value, out string error)
+    {
+        value = HasValue ? ((Some)this).Value : default;
+        error = IsError ? ((Error)this).ErrorValue : default;
+        return HasValue;
+    }
+        
+    public Result<T> Match(Action<T> matchFunc, Action<string> matchError)
+    {
+        if (HasValue) matchFunc(((Some)this).Value);
+        if (IsError) matchError(((Error)this).ErrorValue);
+        return this;
+    }
+
+    public TResult Match<TResult>(Func<T, TResult> matchFunc, Func<string, TResult> matchError) =>
+        HasValue
+            ? matchFunc(((Some)this).Value)
+            : matchError(((Error)this).ErrorValue);
+}

--- a/TF_Service_dotNet/TouchFreeTests/Connections/ClientConnectionManagerTests.cs
+++ b/TF_Service_dotNet/TouchFreeTests/Connections/ClientConnectionManagerTests.cs
@@ -17,8 +17,9 @@ namespace TouchFreeTests.Connections
         public void SendMessageMethods_Called_CallsSimilarlyNamedMethodOnClientConnection(string clientConnectionMethod)
         {
             // Arrange
+            var mockHandManager = CreateHandManagerMockWithMockTrackingConnection();
             var mockClientConnection = CreateClientConnectionMockWithOpenSocket();
-            var clientConnectionManager = new ClientConnectionManager(new Mock<IHandManager>().Object, new Mock<IConfigManager>().Object);
+            var clientConnectionManager = new ClientConnectionManager(mockHandManager.Object, new Mock<IConfigManager>().Object);
             clientConnectionManager.AddConnection(mockClientConnection.Object);
             var methodInfo = typeof(ClientConnectionManager).GetMethod(clientConnectionMethod);
             var parameterInfo = methodInfo.GetParameters();
@@ -47,13 +48,22 @@ namespace TouchFreeTests.Connections
             mockClientConnection.SetupGet(x => x.Socket).Returns(mockWebSocket.Object);
             return mockClientConnection;
         }
+        
+        private Mock<IHandManager> CreateHandManagerMockWithMockTrackingConnection()
+        {
+            var mockHandManager = new Mock<IHandManager>();
+            var mockTrackingConnection = new Mock<ITrackingConnectionManager>();
+            mockHandManager.SetupGet(x => x.ConnectionManager).Returns(mockTrackingConnection.Object);
+            return mockHandManager;
+        }
 
         [Test]
         public void AddConnection_SingleConnection_AddsConnectionToConnections()
         {
             // Arrange
             var mockClientConnection = CreateClientConnectionMockWithOpenSocket();
-            var clientConnectionManager = new ClientConnectionManager(new Mock<IHandManager>().Object, new Mock<IConfigManager>().Object);
+            var mockHandManager = CreateHandManagerMockWithMockTrackingConnection();
+            var clientConnectionManager = new ClientConnectionManager(mockHandManager.Object, new Mock<IConfigManager>().Object);
 
             // Act
             clientConnectionManager.AddConnection(mockClientConnection.Object);
@@ -66,7 +76,7 @@ namespace TouchFreeTests.Connections
         public void RemoveConnection_SingleConnection_ConnectionsAreEmptyAndDisconnectFromTrackingCalled()
         {
             // Arrange
-            var mockHandManager = new Mock<IHandManager>();
+            var mockHandManager = CreateHandManagerMockWithMockTrackingConnection();
             var mockClientConnection = CreateClientConnectionMockWithOpenSocket();
             var clientConnectionManager = new ClientConnectionManager(mockHandManager.Object, new Mock<IConfigManager>().Object);
             clientConnectionManager.AddConnection(mockClientConnection.Object);
@@ -83,7 +93,7 @@ namespace TouchFreeTests.Connections
         public void RemoveConnection_TwoConnections_ConnectionsHaveNonRemovedConnectionAndDisconnectFromTrackingNotCalled()
         {
             // Arrange
-            var mockHandManager = new Mock<IHandManager>();
+            var mockHandManager = CreateHandManagerMockWithMockTrackingConnection();
             var mockClientConnection = CreateClientConnectionMockWithOpenSocket();
             var mockSecondClientConnection = CreateClientConnectionMockWithOpenSocket();
             var clientConnectionManager = new ClientConnectionManager(mockHandManager.Object, new Mock<IConfigManager>().Object);

--- a/TF_Service_dotNet/TouchFreeTests/Connections/ClientConnectionManagerTests.cs
+++ b/TF_Service_dotNet/TouchFreeTests/Connections/ClientConnectionManagerTests.cs
@@ -4,6 +4,7 @@ using System;
 using System.Linq;
 using System.Net.WebSockets;
 using Ultraleap.TouchFree.Library;
+using Ultraleap.TouchFree.Library.Configuration;
 using Ultraleap.TouchFree.Library.Connections;
 
 namespace TouchFreeTests.Connections
@@ -17,7 +18,7 @@ namespace TouchFreeTests.Connections
         {
             // Arrange
             var mockClientConnection = CreateClientConnectionMockWithOpenSocket();
-            var clientConnectionManager = new ClientConnectionManager(new Mock<IHandManager>().Object);
+            var clientConnectionManager = new ClientConnectionManager(new Mock<IHandManager>().Object, new Mock<IConfigManager>().Object);
             clientConnectionManager.AddConnection(mockClientConnection.Object);
             var methodInfo = typeof(ClientConnectionManager).GetMethod(clientConnectionMethod);
             var parameterInfo = methodInfo.GetParameters();
@@ -52,7 +53,7 @@ namespace TouchFreeTests.Connections
         {
             // Arrange
             var mockClientConnection = CreateClientConnectionMockWithOpenSocket();
-            var clientConnectionManager = new ClientConnectionManager(new Mock<IHandManager>().Object);
+            var clientConnectionManager = new ClientConnectionManager(new Mock<IHandManager>().Object, new Mock<IConfigManager>().Object);
 
             // Act
             clientConnectionManager.AddConnection(mockClientConnection.Object);
@@ -67,7 +68,7 @@ namespace TouchFreeTests.Connections
             // Arrange
             var mockHandManager = new Mock<IHandManager>();
             var mockClientConnection = CreateClientConnectionMockWithOpenSocket();
-            var clientConnectionManager = new ClientConnectionManager(mockHandManager.Object);
+            var clientConnectionManager = new ClientConnectionManager(mockHandManager.Object, new Mock<IConfigManager>().Object);
             clientConnectionManager.AddConnection(mockClientConnection.Object);
 
             // Act
@@ -75,7 +76,7 @@ namespace TouchFreeTests.Connections
 
             // Assert
             Assert.AreEqual(0, clientConnectionManager.ClientConnections.Count());
-            mockHandManager.Verify(x => x.DisconnectFromTracking(), Times.Once);
+            mockHandManager.Verify(x => x.ConnectionManager.Disconnect(), Times.Once);
         }
 
         [Test]
@@ -85,7 +86,7 @@ namespace TouchFreeTests.Connections
             var mockHandManager = new Mock<IHandManager>();
             var mockClientConnection = CreateClientConnectionMockWithOpenSocket();
             var mockSecondClientConnection = CreateClientConnectionMockWithOpenSocket();
-            var clientConnectionManager = new ClientConnectionManager(mockHandManager.Object);
+            var clientConnectionManager = new ClientConnectionManager(mockHandManager.Object, new Mock<IConfigManager>().Object);
             clientConnectionManager.AddConnection(mockClientConnection.Object);
             clientConnectionManager.AddConnection(mockSecondClientConnection.Object);
 
@@ -95,7 +96,7 @@ namespace TouchFreeTests.Connections
             // Assert
             Assert.AreEqual(1, clientConnectionManager.ClientConnections.Count());
             Assert.AreSame(mockSecondClientConnection.Object, clientConnectionManager.ClientConnections.Single());
-            mockHandManager.Verify(x => x.DisconnectFromTracking(), Times.Never);
+            mockHandManager.Verify(x => x.ConnectionManager.Disconnect(), Times.Never);
         }
     }
 }

--- a/TF_Service_dotNet/TouchFreeTests/Connections/ClientConnectionTests.cs
+++ b/TF_Service_dotNet/TouchFreeTests/Connections/ClientConnectionTests.cs
@@ -22,7 +22,7 @@ namespace TouchFreeTests.Connections
             var parsedServiceVersion = new Version(serviceVersion);
 
             // Act
-            var result = clientConnection.GetVersionCompability(clientVersion, parsedServiceVersion);
+            var result = ClientConnection.GetVersionCompability(clientVersion, parsedServiceVersion);
 
             // Assert
             Assert.AreEqual(expectedCompatibility, result);

--- a/TF_Service_dotNet/TouchFreeTests/HandManagerTests.cs
+++ b/TF_Service_dotNet/TouchFreeTests/HandManagerTests.cs
@@ -1,7 +1,9 @@
 ﻿using Leap;
+using Moq;
 using NUnit.Framework;
 using Ultraleap.TouchFree.Library;
 using Ultraleap.TouchFree.Library.Configuration;
+using Ultraleap.TouchFree.Library.Connections;
 
 namespace TouchFreeTests
 {
@@ -31,7 +33,18 @@ namespace TouchFreeTests
 
         private HandManager CreateSut()
         {
-            return new(null, null, null);
+            var controller = new Mock<IController>();
+            controller.SetupAllProperties();
+            var connectionManager = new Mock<ITrackingConnectionManager>();
+            connectionManager.SetupAllProperties();
+            connectionManager.SetupGet(manager => manager.Controller).Returns(controller.Object);
+            var physicalConfig = new Mock<PhysicalConfigInternal>();
+            var configManager = new Mock<IConfigManager>();
+            configManager.SetupAllProperties();
+            configManager.SetupGet(manager => manager.PhysicalConfig).Returns(physicalConfig.Object);
+            var virtualScreen = new Mock<IVirtualScreen>();
+            virtualScreen.SetupAllProperties();
+            return new(connectionManager.Object, configManager.Object, virtualScreen.Object);
         }
 
         #region UpdateTrackingTransform

--- a/TF_Service_dotNet/TouchFree_Service/Properties/launchSettings.json
+++ b/TF_Service_dotNet/TouchFree_Service/Properties/launchSettings.json
@@ -2,11 +2,10 @@
   "profiles": {
     "TouchFree_Service": {
       "commandName": "Project",
-      "launchBrowser": true,
+      "launchBrowser": false,
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
-      },
-      "applicationUrl": "https://localhost:52463;http://localhost:52464"
+      }
     }
   }
 }

--- a/TF_Settings_Web/src/App.tsx
+++ b/TF_Settings_Web/src/App.tsx
@@ -25,12 +25,8 @@ const App: React.FC = () => {
             }
         });
 
-        const updateTfStatus = (serviceStatus:TrackingServiceState) => {
-            setTfStatus(serviceStatus);
-        };
-
         ConnectionManager.AddConnectionListener(requestServiceStatus);
-        ConnectionManager.AddServiceStatusListener(updateTfStatus);
+        ConnectionManager.AddServiceStatusListener(setTfStatus);
         const controller: WebInputController = new WebInputController();
 
         new CursorManager();

--- a/TF_Settings_Web/src/App.tsx
+++ b/TF_Settings_Web/src/App.tsx
@@ -41,7 +41,7 @@ const App: React.FC = () => {
             <ControlBar tfStatus={tfStatus} />
             <div className="page-content">
                 <Routes>
-                    <Route path="/settings/camera/*" element={<CameraManager tfStatus={tfStatus} />} />
+                    <Route path="/settings/camera/*" element={<CameraManager />} />
                     <Route path="/settings/interactions" element={<InteractionsPage />} />
                     <Route path="*" element={<Navigate to="/settings/camera" replace />} />
                 </Routes>

--- a/TF_Settings_Web/src/App.tsx
+++ b/TF_Settings_Web/src/App.tsx
@@ -16,27 +16,26 @@ const App: React.FC = () => {
     const [tfStatus, setTfStatus] = React.useState<TrackingServiceState>(TrackingServiceState.UNAVAILABLE);
 
     useEffect(() => {
-        const updateTfStatus = () => {
-            ConnectionManager.RequestServiceStatus((detail: ServiceStatus) => {
-                const status = detail.trackingServiceState;
-                if (status) {
-                    setTfStatus(status);
-                }
-            });
+        ConnectionManager.RequestServiceStatus((detail: ServiceStatus) => {
+            const status = detail.trackingServiceState;
+            if (status) {
+                setTfStatus(status);
+            }
+        });
+
+        const updateTfStatus = (serviceStatus:TrackingServiceState) => {
+            setTfStatus(serviceStatus);
         };
 
         ConnectionManager.init();
 
-        ConnectionManager.AddConnectionListener(updateTfStatus);
+        ConnectionManager.AddServiceStatusListener(updateTfStatus);
         const controller: WebInputController = new WebInputController();
-
-        const timerID = window.setInterval(updateTfStatus, 5000);
 
         new CursorManager();
 
         return () => {
             controller.disconnect();
-            clearInterval(timerID);
         };
     }, []);
 
@@ -45,7 +44,7 @@ const App: React.FC = () => {
             <ControlBar tfStatus={tfStatus} />
             <div className="page-content">
                 <Routes>
-                    <Route path="/settings/camera/*" element={<CameraManager />} />
+                    <Route path="/settings/camera/*" element={<CameraManager tfStatus={tfStatus} />} />
                     <Route path="/settings/interactions" element={<InteractionsPage />} />
                     <Route path="*" element={<Navigate to="/settings/camera" replace />} />
                 </Routes>

--- a/TF_Settings_Web/src/App.tsx
+++ b/TF_Settings_Web/src/App.tsx
@@ -16,7 +16,9 @@ const App: React.FC = () => {
     const [tfStatus, setTfStatus] = React.useState<TrackingServiceState>(TrackingServiceState.UNAVAILABLE);
 
     useEffect(() => {
-        ConnectionManager.RequestServiceStatus((detail: ServiceStatus) => {
+        ConnectionManager.init();
+
+        const requestServiceStatus = () => ConnectionManager.RequestServiceStatus((detail: ServiceStatus) => {
             const status = detail.trackingServiceState;
             if (status) {
                 setTfStatus(status);
@@ -27,8 +29,7 @@ const App: React.FC = () => {
             setTfStatus(serviceStatus);
         };
 
-        ConnectionManager.init();
-
+        ConnectionManager.AddConnectionListener(requestServiceStatus);
         ConnectionManager.AddServiceStatusListener(updateTfStatus);
         const controller: WebInputController = new WebInputController();
 

--- a/TF_Settings_Web/src/Components/Pages/Camera/CameraManager.tsx
+++ b/TF_Settings_Web/src/Components/Pages/Camera/CameraManager.tsx
@@ -1,23 +1,17 @@
 import { Route, Routes } from 'react-router-dom';
-import { TrackingServiceState } from 'TouchFree/TouchFreeToolingTypes';
 
 import CameraSetupScreen from './CameraSetupScreen';
 import { ManualSetupScreen } from './ManualSetupScreen';
 import MaskingScreen from './Masking/MaskingScreen';
 import QuickSetupManager from './QuickSetup/QuickSetupManager';
 
-interface CameraManagerProps
-{
-    tfStatus:TrackingServiceState;
-}
-
-const CameraManager: React.FC<CameraManagerProps> = (props:CameraManagerProps) => {
+const CameraManager: React.FC = () => {
     return (
         <Routes>
             <Route path="" element={<CameraSetupScreen />} />
             <Route path="quick/*" element={<QuickSetupManager />} />
             <Route path="manual" element={<ManualSetupScreen />} />
-            <Route path="masking" element={<MaskingScreen tfStatus={props.tfStatus} />} />
+            <Route path="masking" element={<MaskingScreen />} />
         </Routes>
     );
 };

--- a/TF_Settings_Web/src/Components/Pages/Camera/CameraManager.tsx
+++ b/TF_Settings_Web/src/Components/Pages/Camera/CameraManager.tsx
@@ -1,17 +1,23 @@
 import { Route, Routes } from 'react-router-dom';
+import { TrackingServiceState } from 'TouchFree/TouchFreeToolingTypes';
 
 import CameraSetupScreen from './CameraSetupScreen';
 import { ManualSetupScreen } from './ManualSetupScreen';
 import MaskingScreen from './Masking/MaskingScreen';
 import QuickSetupManager from './QuickSetup/QuickSetupManager';
 
-const CameraManager = () => {
+interface CameraManagerProps
+{
+    tfStatus:TrackingServiceState;
+}
+
+const CameraManager: React.FC<CameraManagerProps> = (props:CameraManagerProps) => {
     return (
         <Routes>
             <Route path="" element={<CameraSetupScreen />} />
             <Route path="quick/*" element={<QuickSetupManager />} />
             <Route path="manual" element={<ManualSetupScreen />} />
-            <Route path="masking" element={<MaskingScreen />} />
+            <Route path="masking" element={<MaskingScreen tfStatus={props.tfStatus} />} />
         </Routes>
     );
 };

--- a/TF_Settings_Web/src/Components/Pages/Camera/Masking/MaskingScreen.tsx
+++ b/TF_Settings_Web/src/Components/Pages/Camera/Masking/MaskingScreen.tsx
@@ -7,7 +7,7 @@ import { useStatefulRef } from 'customHooks';
 
 import { TrackingStateResponse } from 'TouchFree/Connection/TouchFreeServiceTypes';
 import { HandDataManager } from 'TouchFree/Plugins/HandDataManager';
-import { HandFrame, TrackingServiceState } from 'TouchFree/TouchFreeToolingTypes';
+import { HandFrame } from 'TouchFree/TouchFreeToolingTypes';
 import { TrackingManager } from 'TouchFree/Tracking/TrackingManager';
 import { Mask } from 'TouchFree/Tracking/TrackingTypes';
 
@@ -23,12 +23,7 @@ export type Lens = 'Left' | 'Right';
 
 const FRAME_PROCESSING_TIMEOUT = 60;
 
-interface MaskingScreenProps
-{
-    tfStatus:TrackingServiceState;
-}
-
-const MaskingScreen: React.FC<MaskingScreenProps> = (props:MaskingScreenProps) => {
+const MaskingScreen: React.FC = () => {
     // ===== State =====
     const mainLens = useStatefulRef<Lens>('Left');
     const handData = useStatefulRef<HandState>(defaultHandState);

--- a/TF_Settings_Web/src/Components/Pages/Camera/Masking/MaskingScreen.tsx
+++ b/TF_Settings_Web/src/Components/Pages/Camera/Masking/MaskingScreen.tsx
@@ -7,7 +7,7 @@ import { useStatefulRef } from 'customHooks';
 
 import { TrackingStateResponse } from 'TouchFree/Connection/TouchFreeServiceTypes';
 import { HandDataManager } from 'TouchFree/Plugins/HandDataManager';
-import { HandFrame } from 'TouchFree/TouchFreeToolingTypes';
+import { HandFrame, TrackingServiceState } from 'TouchFree/TouchFreeToolingTypes';
 import { TrackingManager } from 'TouchFree/Tracking/TrackingManager';
 import { Mask } from 'TouchFree/Tracking/TrackingTypes';
 
@@ -23,7 +23,12 @@ export type Lens = 'Left' | 'Right';
 
 const FRAME_PROCESSING_TIMEOUT = 60;
 
-const MaskingScreen = () => {
+interface MaskingScreenProps
+{
+    tfStatus:TrackingServiceState;
+}
+
+const MaskingScreen: React.FC<MaskingScreenProps> = (props:MaskingScreenProps) => {
     // ===== State =====
     const mainLens = useStatefulRef<Lens>('Left');
     const handData = useStatefulRef<HandState>(defaultHandState);
@@ -238,7 +243,6 @@ const MaskingScreen = () => {
                 {sliders}
                 <div className="cam-feed-box-feed">
                     <canvas ref={canvasRef} width={'192px'} height={'192px'} />
-
                     <HandsSvg key="hand-data" one={handData.current.one} two={handData.current.two} />
                 </div>
                 <div className="lens-toggle-container">{lensToggles}</div>

--- a/TF_Settings_Web/src/TouchFree/Connection/ConnectionManager.ts
+++ b/TF_Settings_Web/src/TouchFree/Connection/ConnectionManager.ts
@@ -1,4 +1,4 @@
-
+import { TouchFreeEvent, TrackingServiceState } from "../TouchFreeToolingTypes";
 import { MessageReceiver } from "./MessageReceiver";
 import { ServiceConnection } from "./ServiceConnection";
 import { HandPresenceState, ServiceStatus } from "./TouchFreeServiceTypes";
@@ -7,125 +7,136 @@ import { HandPresenceState, ServiceStatus } from "./TouchFreeServiceTypes";
 // This Class manages the connection to the Service. It provides static variables
 // for ease of use and is a Singleton to allow for easy referencing.
 export class ConnectionManager extends EventTarget {
+  // Group: Events
 
-    // Group: Events
+  // Event: OnConnected
+  // An event which is emitted when <Connect> is called.
+  //
+  // Instead of adding listeners to this event, use <AddConnectionListener> to ensure that your
+  // function is invoked if the connection has already been made by the time your class runs.
 
-    // Event: OnConnected
-    // An event which is emitted when <Connect> is called.
-    //
-    // Instead of adding listeners to this event, use <AddConnectionListener> to ensure that your
-    // function is invoked if the connection has already been made by the time your class runs.
+  // Group: Variables
 
-    // Group: Variables
+  // Variable: currentServiceConnection
+  // The private reference to the currently managed <ServiceConnection>.
+  private static currentServiceConnection: ServiceConnection | null;
 
-    // Variable: currentServiceConnection
-    // The private reference to the currently managed <ServiceConnection>.
-    private static currentServiceConnection: ServiceConnection | null;
-
-    // Variable: serviceConnection
-    // The public get-only reference to the currently managed <ServiceConnection>.
-    public static serviceConnection(): ServiceConnection | null {
-        return ConnectionManager.currentServiceConnection;
-    };
-
-    // Variable: messageReceiver
-    // A reference to the receiver that handles destribution of data received via the <currentServiceConnection> if connected.
-    public static messageReceiver: MessageReceiver;
-
-    // Variable: instance
-    // The instance of the singleton for referencing the events transmitted
-    public static instance: ConnectionManager;
-
-    // Variable: iPAddress
-    // The IP Address that will be used in the <ServiceConnection> to connect to the target
-    // WebSocket. This value is settable in the Inspector.
-    static iPAddress: string = "127.0.0.1";
-
-    // Variable: port
-    // The Port that will be used in the <ServiceConnection> to connect to the target WebSocket.
-    // This value is settable in the Inspector.
-    static port: string = "9739";
-
-    // Variable: currentHandPresence
-    // Private reference to the current hand presense state
-    private static currentHandPresence: HandPresenceState = HandPresenceState.HANDS_LOST;
-
-    // Group: Functions
-
-    // Function: init
-    // Used to begin the connection. Creates the required <MessageReceiver>.
-    // Also attempts to immediately <Connect> to a WebSocket.
-    public static init() {
-        ConnectionManager.messageReceiver = new MessageReceiver();
-        ConnectionManager.instance = new ConnectionManager();
-        ConnectionManager.Connect();
+  // Variable: serviceConnection
+  // The public get-only reference to the currently managed <ServiceConnection>.
+  public static serviceConnection(): ServiceConnection | null {
+    return ConnectionManager.currentServiceConnection;
     }
 
-    // Function: AddConnectionListener
-    // Used to both add the _onConnectFunc action to the listeners of <OnConnected>
-    // as well as auto-call the _onConnectFunc if a connection is already made.
-    public static AddConnectionListener(_onConnectFunc: () => void): void {
-        ConnectionManager.instance.addEventListener('OnConnected', _onConnectFunc);
+  // Variable: messageReceiver
+  // A reference to the receiver that handles destribution of data received via the <currentServiceConnection> if connected.
+  public static messageReceiver: MessageReceiver;
 
-        if (ConnectionManager.currentServiceConnection !== null &&
-            ConnectionManager.currentServiceConnection.webSocket.readyState === WebSocket.OPEN) {
-            _onConnectFunc();
-        }
+  // Variable: instance
+  // The instance of the singleton for referencing the events transmitted
+  public static instance: ConnectionManager;
+
+  // Variable: iPAddress
+  // The IP Address that will be used in the <ServiceConnection> to connect to the target
+  // WebSocket. This value is settable in the Inspector.
+  static iPAddress: string = "127.0.0.1";
+
+  // Variable: port
+  // The Port that will be used in the <ServiceConnection> to connect to the target WebSocket.
+  // This value is settable in the Inspector.
+  static port: string = "9739";
+
+  // Variable: currentHandPresence
+  // Private reference to the current hand presense state
+  private static currentHandPresence: HandPresenceState =
+    HandPresenceState.HANDS_LOST;
+
+  // Group: Functions
+
+  // Function: init
+  // Used to begin the connection. Creates the required <MessageReceiver>.
+  // Also attempts to immediately <Connect> to a WebSocket.
+  public static init() {
+    ConnectionManager.messageReceiver = new MessageReceiver();
+    ConnectionManager.instance = new ConnectionManager();
+    ConnectionManager.Connect();
+  }
+
+  // Function: AddConnectionListener
+  // Used to both add the _onConnectFunc action to the listeners of <OnConnected>
+  // as well as auto-call the _onConnectFunc if a connection is already made.
+  public static AddConnectionListener(_onConnectFunc: () => void): void {
+    ConnectionManager.instance.addEventListener(TouchFreeEvent.ON_CONNECTED, _onConnectFunc);
+
+    if (
+      ConnectionManager.currentServiceConnection !== null &&
+      ConnectionManager.currentServiceConnection.webSocket.readyState ===
+        WebSocket.OPEN
+    ) {
+      _onConnectFunc();
+    }
+  }
+
+  public static AddServiceStatusListener(_serviceStatusFunc: (serviceStatus:TrackingServiceState) => void):void {
+    ConnectionManager.instance.addEventListener(TouchFreeEvent.ON_TRACKING_SERVICE_STATE_CHANGE,
+      ((evt:CustomEvent<TrackingServiceState>) => {_serviceStatusFunc(evt.detail)}) as EventListener);
+  }
+
+  // Function: Connect
+  // Creates a new <ServiceConnection> using <iPAddress> and <port>.
+  // Also invokes <OnConnected> on all listeners.
+  public static Connect(): void {
+    ConnectionManager.currentServiceConnection = new ServiceConnection(
+      ConnectionManager.iPAddress,
+      ConnectionManager.port,
+    );
+  }
+
+  // Function: HandleHandPresenceEvent
+  // Called by the <MessageReciever> to pass HandPresence events via the <HandFound> and
+  // <HandsLost> events on this class
+  public static HandleHandPresenceEvent(_state: HandPresenceState): void {
+    ConnectionManager.currentHandPresence = _state;
+
+    let handPresenceEvent: Event;
+
+    if (_state === HandPresenceState.HAND_FOUND) {
+      handPresenceEvent = new Event(TouchFreeEvent.HAND_FOUND);
+    } else {
+      handPresenceEvent = new Event(TouchFreeEvent.HANDS_LOST);
     }
 
-    // Function: Connect
-    // Creates a new <ServiceConnection> using <iPAddress> and <port>.
-    // Also invokes <OnConnected> on all listeners.
-    public static Connect(): void {
-        ConnectionManager.currentServiceConnection = new ServiceConnection(
-            ConnectionManager.iPAddress,
-            ConnectionManager.port);
+    ConnectionManager.instance.dispatchEvent(handPresenceEvent);
+  }
+
+  // Function: Disconnect
+  // Disconnects <currentServiceConnection> if it is connected to a WebSocket and
+  // sets it to null.
+  public static Disconnect(): void {
+    if (ConnectionManager.currentServiceConnection !== null) {
+      ConnectionManager.currentServiceConnection.Disconnect();
+      ConnectionManager.currentServiceConnection = null;
+    }
+  }
+
+  // Function: RequestServiceStatus
+  // Used to request information from the Service via the <ConnectionManager>. Provides an asynchronous
+  // <ServiceStatus> via the _callback parameter.
+  //
+  // If your _callback requires context it should be bound to that context via .bind()
+  public static RequestServiceStatus(
+    _callback: (detail: ServiceStatus) => void,
+  ): void {
+    if (_callback === null) {
+      console.error("Request failed. This is due to a missing callback");
+      return;
     }
 
-    // Function: HandleHandPresenceEvent
-    // Called by the <MessageReciever> to pass HandPresence events via the <HandFound> and
-    // <HandsLost> events on this class
-    public static HandleHandPresenceEvent(_state: HandPresenceState): void {
-        ConnectionManager.currentHandPresence = _state;
-        
-        let handPresenceEvent: CustomEvent;
+    ConnectionManager.serviceConnection()?.RequestServiceStatus(_callback);
+  }
 
-        if (_state === HandPresenceState.HAND_FOUND) {
-            handPresenceEvent = new CustomEvent('HandFound');
-        } else {
-            handPresenceEvent = new CustomEvent('HandsLost');
-        }
-
-        ConnectionManager.instance.dispatchEvent(handPresenceEvent);
-    }
-
-    // Function: Disconnect
-    // Disconnects <currentServiceConnection> if it is connected to a WebSocket and
-    // sets it to null.
-    public static Disconnect(): void {
-        if (ConnectionManager.currentServiceConnection !== null) {
-            ConnectionManager.currentServiceConnection.Disconnect();
-            ConnectionManager.currentServiceConnection = null;
-        }
-    }
-
-    // Function: RequestServiceStatus
-    // Used to request information from the Service via the <ConnectionManager>. Provides an asynchronous
-    // <ServiceStatus> via the _callback parameter.
-    //
-    // If your _callback requires context it should be bound to that context via .bind()
-    public static RequestServiceStatus(_callback: (detail: ServiceStatus) => void): void {
-        if (_callback === null) {
-            console.error("Request failed. This is due to a missing callback");
-            return;
-        }
-
-        ConnectionManager.serviceConnection()?.RequestServiceStatus(_callback);
-    }
-
-    // Function: RequestServiceStatus
-    // Function to get the current hand presense state
-    public static GetCurrentHandPresence(): HandPresenceState {
-        return ConnectionManager.currentHandPresence;
-    }
+  // Function: RequestServiceStatus
+  // Function to get the current hand presense state
+  public static GetCurrentHandPresence(): HandPresenceState {
+    return ConnectionManager.currentHandPresence;
+  }
 }

--- a/TF_Settings_Web/src/TouchFree/Connection/ConnectionManager.ts
+++ b/TF_Settings_Web/src/TouchFree/Connection/ConnectionManager.ts
@@ -7,136 +7,136 @@ import { HandPresenceState, ServiceStatus } from "./TouchFreeServiceTypes";
 // This Class manages the connection to the Service. It provides static variables
 // for ease of use and is a Singleton to allow for easy referencing.
 export class ConnectionManager extends EventTarget {
-  // Group: Events
+    // Group: Events
 
-  // Event: OnConnected
-  // An event which is emitted when <Connect> is called.
-  //
-  // Instead of adding listeners to this event, use <AddConnectionListener> to ensure that your
-  // function is invoked if the connection has already been made by the time your class runs.
+    // Event: OnConnected
+    // An event which is emitted when <Connect> is called.
+    //
+    // Instead of adding listeners to this event, use <AddConnectionListener> to ensure that your
+    // function is invoked if the connection has already been made by the time your class runs.
 
-  // Group: Variables
+    // Group: Variables
 
-  // Variable: currentServiceConnection
-  // The private reference to the currently managed <ServiceConnection>.
-  private static currentServiceConnection: ServiceConnection | null;
+    // Variable: currentServiceConnection
+    // The private reference to the currently managed <ServiceConnection>.
+    private static currentServiceConnection: ServiceConnection | null;
 
-  // Variable: serviceConnection
-  // The public get-only reference to the currently managed <ServiceConnection>.
-  public static serviceConnection(): ServiceConnection | null {
-    return ConnectionManager.currentServiceConnection;
+    // Variable: serviceConnection
+    // The public get-only reference to the currently managed <ServiceConnection>.
+    public static serviceConnection(): ServiceConnection | null {
+        return ConnectionManager.currentServiceConnection;
     }
 
-  // Variable: messageReceiver
-  // A reference to the receiver that handles destribution of data received via the <currentServiceConnection> if connected.
-  public static messageReceiver: MessageReceiver;
+    // Variable: messageReceiver
+    // A reference to the receiver that handles destribution of data received via the <currentServiceConnection> if connected.
+    public static messageReceiver: MessageReceiver;
 
-  // Variable: instance
-  // The instance of the singleton for referencing the events transmitted
-  public static instance: ConnectionManager;
+    // Variable: instance
+    // The instance of the singleton for referencing the events transmitted
+    public static instance: ConnectionManager;
 
-  // Variable: iPAddress
-  // The IP Address that will be used in the <ServiceConnection> to connect to the target
-  // WebSocket. This value is settable in the Inspector.
-  static iPAddress: string = "127.0.0.1";
+    // Variable: iPAddress
+    // The IP Address that will be used in the <ServiceConnection> to connect to the target
+    // WebSocket. This value is settable in the Inspector.
+    static iPAddress: string = "127.0.0.1";
 
-  // Variable: port
-  // The Port that will be used in the <ServiceConnection> to connect to the target WebSocket.
-  // This value is settable in the Inspector.
-  static port: string = "9739";
+    // Variable: port
+    // The Port that will be used in the <ServiceConnection> to connect to the target WebSocket.
+    // This value is settable in the Inspector.
+    static port: string = "9739";
 
-  // Variable: currentHandPresence
-  // Private reference to the current hand presense state
-  private static currentHandPresence: HandPresenceState =
-    HandPresenceState.HANDS_LOST;
+    // Variable: currentHandPresence
+    // Private reference to the current hand presense state
+    private static currentHandPresence: HandPresenceState =
+        HandPresenceState.HANDS_LOST;
 
-  // Group: Functions
+    // Group: Functions
 
-  // Function: init
-  // Used to begin the connection. Creates the required <MessageReceiver>.
-  // Also attempts to immediately <Connect> to a WebSocket.
-  public static init() {
-    ConnectionManager.messageReceiver = new MessageReceiver();
-    ConnectionManager.instance = new ConnectionManager();
-    ConnectionManager.Connect();
-  }
-
-  // Function: AddConnectionListener
-  // Used to both add the _onConnectFunc action to the listeners of <OnConnected>
-  // as well as auto-call the _onConnectFunc if a connection is already made.
-  public static AddConnectionListener(_onConnectFunc: () => void): void {
-    ConnectionManager.instance.addEventListener(TouchFreeEvent.ON_CONNECTED, _onConnectFunc);
-
-    if (
-      ConnectionManager.currentServiceConnection !== null &&
-      ConnectionManager.currentServiceConnection.webSocket.readyState ===
-        WebSocket.OPEN
-    ) {
-      _onConnectFunc();
-    }
-  }
-
-  public static AddServiceStatusListener(_serviceStatusFunc: (serviceStatus:TrackingServiceState) => void):void {
-    ConnectionManager.instance.addEventListener(TouchFreeEvent.ON_TRACKING_SERVICE_STATE_CHANGE,
-      ((evt:CustomEvent<TrackingServiceState>) => {_serviceStatusFunc(evt.detail)}) as EventListener);
-  }
-
-  // Function: Connect
-  // Creates a new <ServiceConnection> using <iPAddress> and <port>.
-  // Also invokes <OnConnected> on all listeners.
-  public static Connect(): void {
-    ConnectionManager.currentServiceConnection = new ServiceConnection(
-      ConnectionManager.iPAddress,
-      ConnectionManager.port,
-    );
-  }
-
-  // Function: HandleHandPresenceEvent
-  // Called by the <MessageReciever> to pass HandPresence events via the <HandFound> and
-  // <HandsLost> events on this class
-  public static HandleHandPresenceEvent(_state: HandPresenceState): void {
-    ConnectionManager.currentHandPresence = _state;
-
-    let handPresenceEvent: Event;
-
-    if (_state === HandPresenceState.HAND_FOUND) {
-      handPresenceEvent = new Event(TouchFreeEvent.HAND_FOUND);
-    } else {
-      handPresenceEvent = new Event(TouchFreeEvent.HANDS_LOST);
+    // Function: init
+    // Used to begin the connection. Creates the required <MessageReceiver>.
+    // Also attempts to immediately <Connect> to a WebSocket.
+    public static init() {
+        ConnectionManager.messageReceiver = new MessageReceiver();
+        ConnectionManager.instance = new ConnectionManager();
+        ConnectionManager.Connect();
     }
 
-    ConnectionManager.instance.dispatchEvent(handPresenceEvent);
-  }
+    // Function: AddConnectionListener
+    // Used to both add the _onConnectFunc action to the listeners of <OnConnected>
+    // as well as auto-call the _onConnectFunc if a connection is already made.
+    public static AddConnectionListener(_onConnectFunc: () => void): void {
+        ConnectionManager.instance.addEventListener(TouchFreeEvent.ON_CONNECTED, _onConnectFunc);
 
-  // Function: Disconnect
-  // Disconnects <currentServiceConnection> if it is connected to a WebSocket and
-  // sets it to null.
-  public static Disconnect(): void {
-    if (ConnectionManager.currentServiceConnection !== null) {
-      ConnectionManager.currentServiceConnection.Disconnect();
-      ConnectionManager.currentServiceConnection = null;
-    }
-  }
-
-  // Function: RequestServiceStatus
-  // Used to request information from the Service via the <ConnectionManager>. Provides an asynchronous
-  // <ServiceStatus> via the _callback parameter.
-  //
-  // If your _callback requires context it should be bound to that context via .bind()
-  public static RequestServiceStatus(
-    _callback: (detail: ServiceStatus) => void,
-  ): void {
-    if (_callback === null) {
-      console.error("Request failed. This is due to a missing callback");
-      return;
+        if (
+            ConnectionManager.currentServiceConnection !== null &&
+            ConnectionManager.currentServiceConnection.webSocket.readyState ===
+            WebSocket.OPEN
+        ) {
+            _onConnectFunc();
+        }
     }
 
-    ConnectionManager.serviceConnection()?.RequestServiceStatus(_callback);
-  }
+    public static AddServiceStatusListener(_serviceStatusFunc: (serviceStatus: TrackingServiceState) => void): void {
+        ConnectionManager.instance.addEventListener(TouchFreeEvent.ON_TRACKING_SERVICE_STATE_CHANGE,
+            ((evt: CustomEvent<TrackingServiceState>) => { _serviceStatusFunc(evt.detail) }) as EventListener);
+    }
 
-  // Function: RequestServiceStatus
-  // Function to get the current hand presense state
-  public static GetCurrentHandPresence(): HandPresenceState {
-    return ConnectionManager.currentHandPresence;
-  }
+    // Function: Connect
+    // Creates a new <ServiceConnection> using <iPAddress> and <port>.
+    // Also invokes <OnConnected> on all listeners.
+    public static Connect(): void {
+        ConnectionManager.currentServiceConnection = new ServiceConnection(
+            ConnectionManager.iPAddress,
+            ConnectionManager.port,
+        );
+    }
+
+    // Function: HandleHandPresenceEvent
+    // Called by the <MessageReciever> to pass HandPresence events via the <HandFound> and
+    // <HandsLost> events on this class
+    public static HandleHandPresenceEvent(_state: HandPresenceState): void {
+        ConnectionManager.currentHandPresence = _state;
+
+        let handPresenceEvent: Event;
+
+        if (_state === HandPresenceState.HAND_FOUND) {
+            handPresenceEvent = new Event(TouchFreeEvent.HAND_FOUND);
+        } else {
+            handPresenceEvent = new Event(TouchFreeEvent.HANDS_LOST);
+        }
+
+        ConnectionManager.instance.dispatchEvent(handPresenceEvent);
+    }
+
+    // Function: Disconnect
+    // Disconnects <currentServiceConnection> if it is connected to a WebSocket and
+    // sets it to null.
+    public static Disconnect(): void {
+        if (ConnectionManager.currentServiceConnection !== null) {
+            ConnectionManager.currentServiceConnection.Disconnect();
+            ConnectionManager.currentServiceConnection = null;
+        }
+    }
+
+    // Function: RequestServiceStatus
+    // Used to request information from the Service via the <ConnectionManager>. Provides an asynchronous
+    // <ServiceStatus> via the _callback parameter.
+    //
+    // If your _callback requires context it should be bound to that context via .bind()
+    public static RequestServiceStatus(
+        _callback: (detail: ServiceStatus) => void,
+    ): void {
+        if (_callback === null) {
+            console.error("Request failed. This is due to a missing callback");
+            return;
+        }
+
+        ConnectionManager.serviceConnection()?.RequestServiceStatus(_callback);
+    }
+
+    // Function: RequestServiceStatus
+    // Function to get the current hand presense state
+    public static GetCurrentHandPresence(): HandPresenceState {
+        return ConnectionManager.currentHandPresence;
+    }
 }

--- a/TF_Settings_Web/src/TouchFree/Connection/MessageReceiver.ts
+++ b/TF_Settings_Web/src/TouchFree/Connection/MessageReceiver.ts
@@ -203,7 +203,6 @@ export class MessageReceiver {
             // If callback didn't happen for known reasons, we cna be sure it's an independent status event rather than a request response
             if (callbackResult === 'NoCallbacksFound' || callbackResult === 'CallbacksUndefined')
             {
-                console.log(serviceStatus)
                 ConnectionManager.instance.dispatchEvent(
                     new CustomEvent<TrackingServiceState>(TouchFreeEvent.ON_TRACKING_SERVICE_STATE_CHANGE,
                         {detail: serviceStatus.trackingServiceState ?? undefined}));

--- a/TF_Settings_Web/src/TouchFree/Connection/ServiceConnection.ts
+++ b/TF_Settings_Web/src/TouchFree/Connection/ServiceConnection.ts
@@ -1,4 +1,5 @@
 import {
+    TouchFreeEvent,
     VersionInfo,
     WebsocketInputAction
 } from '../TouchFreeToolingTypes';
@@ -96,7 +97,7 @@ export class ServiceConnection {
             console.log("Successful Connection");
 
             this.handshakeCompleted = true;
-            ConnectionManager.instance.dispatchEvent(new Event('OnConnected'));
+            ConnectionManager.instance.dispatchEvent(new Event(TouchFreeEvent.ON_CONNECTED));
         }
         else {
             console.log(`Connection to Service failed. Details:\n${response.message}`);

--- a/TF_Settings_Web/src/TouchFree/Cursors/DotCursor.ts
+++ b/TF_Settings_Web/src/TouchFree/Cursors/DotCursor.ts
@@ -1,7 +1,8 @@
 import { TouchlessCursor } from './TouchlessCursor';
 import {
     TouchFreeInputAction,
-    InputType
+    InputType,
+    TouchFreeEvent
 } from '../TouchFreeToolingTypes';
 import { ConnectionManager } from '../Connection/ConnectionManager';
 import { MapRangeToRange } from '../Utilities';
@@ -59,8 +60,8 @@ export class DotCursor extends TouchlessCursor {
         this.animationSpeed[0] = (this.cursorStartSize[0] / 2) / (_animationDuration * 30);
         this.animationSpeed[1] = (this.cursorStartSize[1] / 2) / (_animationDuration * 30);
 
-        ConnectionManager.instance.addEventListener('HandFound', this.ShowCursor.bind(this));
-        ConnectionManager.instance.addEventListener('HandsLost', this.HideCursor.bind(this));
+        ConnectionManager.instance.addEventListener(TouchFreeEvent.HAND_FOUND, this.ShowCursor.bind(this));
+        ConnectionManager.instance.addEventListener(TouchFreeEvent.HANDS_LOST, this.HideCursor.bind(this));
     }
 
     // Function: UpdateCursor

--- a/TF_Settings_Web/src/TouchFree/Cursors/TouchlessCursor.ts
+++ b/TF_Settings_Web/src/TouchFree/Cursors/TouchlessCursor.ts
@@ -1,4 +1,4 @@
-import { TouchFreeInputAction } from '../TouchFreeToolingTypes';
+import { TouchFreeEvent, TouchFreeInputAction } from '../TouchFreeToolingTypes';
 import { InputActionManager } from '../Plugins/InputActionManager';
 
 
@@ -31,7 +31,7 @@ export abstract class TouchlessCursor {
     // If you intend to make use of the <WebInputController>, make sure that _cursor has the
     // "touchfree-cursor" class. This prevents it blocking other elements from recieving events.
     constructor(_cursor: HTMLElement | SVGElement | undefined) {
-        InputActionManager.instance.addEventListener('TransmitInputAction', ((e: CustomEvent<TouchFreeInputAction>) => {
+        InputActionManager.instance.addEventListener(TouchFreeEvent.TRAMSIT_INPUT_ACTION, ((e: CustomEvent<TouchFreeInputAction>) => {
             this.HandleInputAction(e.detail);
         }) as EventListener);
 

--- a/TF_Settings_Web/src/TouchFree/InputControllers/BaseInputController.ts
+++ b/TF_Settings_Web/src/TouchFree/InputControllers/BaseInputController.ts
@@ -1,5 +1,5 @@
 import { InputActionManager } from '../Plugins/InputActionManager';
-import { TouchFreeInputAction, InputType } from "../TouchFreeToolingTypes";
+import { TouchFreeInputAction, InputType, TouchFreeEvent } from "../TouchFreeToolingTypes";
 
 // Class: InputController
 // InputControllers convert <TouchFreeInputActions> as recieved from the service into appropriate
@@ -20,7 +20,7 @@ export abstract class BaseInputController {
     constructor() {
         if (!BaseInputController.Instantiated) {
             BaseInputController.Instantiated = true;
-            InputActionManager.instance.addEventListener('TransmitInputAction',
+            InputActionManager.instance.addEventListener(TouchFreeEvent.TRAMSIT_INPUT_ACTION,
                 ((e: CustomEvent<TouchFreeInputAction>) => {
                     this.HandleInputAction(e.detail);
                 }) as EventListener);
@@ -55,7 +55,7 @@ export abstract class BaseInputController {
     }
 
     disconnect() {
-        InputActionManager.instance.removeEventListener('TransmitInputAction',
+        InputActionManager.instance.removeEventListener(TouchFreeEvent.TRAMSIT_INPUT_ACTION,
             ((e: CustomEvent<TouchFreeInputAction>) => {
                 this.HandleInputAction(e.detail);
             }) as EventListener);

--- a/TF_Settings_Web/src/TouchFree/InputControllers/WebInputController.ts
+++ b/TF_Settings_Web/src/TouchFree/InputControllers/WebInputController.ts
@@ -1,6 +1,7 @@
 import {
     TouchFreeInputAction,
-    InputType
+    InputType,
+    TouchFreeEvent
 } from '../TouchFreeToolingTypes';
 import { BaseInputController } from './BaseInputController'
 
@@ -112,7 +113,7 @@ export class WebInputController extends BaseInputController {
         this.activeEventProps.clientY = _inputData.CursorPosition[1];
 
         if (elementAtPos !== null) {
-            let inputEvent: CustomEvent = new CustomEvent(`InputAction`, {detail: _inputData})
+            const inputEvent = new CustomEvent<TouchFreeInputAction>(TouchFreeEvent.INPUT_ACTION, {detail: _inputData})
             elementAtPos.dispatchEvent(inputEvent);
         }
 

--- a/TF_Settings_Web/src/TouchFree/Plugins/InputActionManager.ts
+++ b/TF_Settings_Web/src/TouchFree/Plugins/InputActionManager.ts
@@ -1,4 +1,4 @@
-import { TouchFreeInputAction } from "../TouchFreeToolingTypes";
+import { TouchFreeEvent, TouchFreeInputAction } from "../TouchFreeToolingTypes";
 import { InputActionPlugin } from "./InputActionPlugin";
 
 // Class: InputActionManager
@@ -42,7 +42,7 @@ export class InputActionManager extends EventTarget {
     public static HandleInputAction(_action: TouchFreeInputAction): void {
 
         let rawInputActionEvent: CustomEvent<TouchFreeInputAction> = new CustomEvent<TouchFreeInputAction>(
-            'TransmitInputActionRaw',
+            TouchFreeEvent.TRAMSIT_INPUT_ACTION_RAW,
             { detail: _action }
         );
         InputActionManager.instance.dispatchEvent(rawInputActionEvent);
@@ -63,7 +63,7 @@ export class InputActionManager extends EventTarget {
         }
 
         let inputActionEvent: CustomEvent<TouchFreeInputAction> = new CustomEvent<TouchFreeInputAction>(
-            'TransmitInputAction',
+            TouchFreeEvent.TRAMSIT_INPUT_ACTION,
             { detail: action }
         );
 

--- a/TF_Settings_Web/src/TouchFree/Plugins/InputActionPlugin.ts
+++ b/TF_Settings_Web/src/TouchFree/Plugins/InputActionPlugin.ts
@@ -1,4 +1,4 @@
-import { TouchFreeInputAction } from "../TouchFreeToolingTypes";
+import { TouchFreeEvent, TouchFreeInputAction } from "../TouchFreeToolingTypes";
 
 export abstract class InputActionPlugin extends EventTarget{
     // Event: InputActionOutput
@@ -32,7 +32,7 @@ export abstract class InputActionPlugin extends EventTarget{
     // To be used to Invoke the InputActionOutput event from any child class of this base.
     TransmitInputAction(_inputAction: TouchFreeInputAction): void{
         let InputActionEvent: CustomEvent<TouchFreeInputAction> = new CustomEvent<TouchFreeInputAction>(
-            'InputActionOutput',
+            TouchFreeEvent.INPUT_ACTION_OUTPUT,
             { detail: _inputAction }
         );
         this.dispatchEvent(InputActionEvent);

--- a/TF_Settings_Web/src/TouchFree/TouchFreeToolingTypes.ts
+++ b/TF_Settings_Web/src/TouchFree/TouchFreeToolingTypes.ts
@@ -2,86 +2,88 @@ import { Vector } from "./Configuration/ConfigurationTypes";
 
 // Class: VersionInfo
 // This class is used when comparing the <ApiVersion> of the Tooling and the Service.
-export class VersionInfo
-{
-    // Group: Variables
+export class VersionInfo {
+  // Group: Variables
 
-    // Variable: ApiVersion
-    // The current API version of the Tooling.
-    public static readonly ApiVersion: string = "1.3.0";
+  // Variable: ApiVersion
+  // The current API version of the Tooling.
+  public static readonly ApiVersion: string = "1.3.0";
 
-    // Variable: API_HEADER_NAME
-    // The name of the header we wish the Service to compare our version with.
-    public static readonly API_HEADER_NAME: string = "TfApiVersion";
+  // Variable: API_HEADER_NAME
+  // The name of the header we wish the Service to compare our version with.
+  public static readonly API_HEADER_NAME: string = "TfApiVersion";
 }
 
 // Class: TouchFreeInputAction
 // A structure representing the Tooling verison of an InputAction. This is used to pass
 // key information relating to an action that has happened on the Service.
 export class TouchFreeInputAction {
-    Timestamp: number;
-    InteractionType: InteractionType;
-    HandType: HandType;
-    Chirality: HandChirality;
-    InputType: InputType;
-    CursorPosition: Array<number>;
-    DistanceFromScreen: number;
-    ProgressToClick: number;
+  Timestamp: number;
+  InteractionType: InteractionType;
+  HandType: HandType;
+  Chirality: HandChirality;
+  InputType: InputType;
+  CursorPosition: Array<number>;
+  DistanceFromScreen: number;
+  ProgressToClick: number;
 
-    constructor(
-        _timestamp: number,
-        _interactionType: InteractionType,
-        _handType: HandType,
-        _handChirality: HandChirality,
-        _inputType: InputType,
-        _cursorPosition: Array<number>,
-        _distanceFromScreen: number,
-        _progressToClick: number)
-    {
-        this.Timestamp = _timestamp;
-        this.InteractionType = _interactionType;
-        this.HandType = _handType;
-        this.Chirality = _handChirality;
-        this.InputType = _inputType;
-        this.CursorPosition = _cursorPosition;
-        this.DistanceFromScreen = _distanceFromScreen;
-        this.ProgressToClick = _progressToClick;
-    }
+  constructor(
+    _timestamp: number,
+    _interactionType: InteractionType,
+    _handType: HandType,
+    _handChirality: HandChirality,
+    _inputType: InputType,
+    _cursorPosition: Array<number>,
+    _distanceFromScreen: number,
+    _progressToClick: number,
+  ) {
+    this.Timestamp = _timestamp;
+    this.InteractionType = _interactionType;
+    this.HandType = _handType;
+    this.Chirality = _handChirality;
+    this.InputType = _inputType;
+    this.CursorPosition = _cursorPosition;
+    this.DistanceFromScreen = _distanceFromScreen;
+    this.ProgressToClick = _progressToClick;
+  }
 }
 
 // Function: ConvertInputAction
 // Used to translate the raw actions that come across the websocket (<WebsocketInputActions>) and
 // convert them into the Tooling-friendly <TouchFreeInputAction> format.
-export function ConvertInputAction(_wsInput: WebsocketInputAction): TouchFreeInputAction {
-    const yPosition = window.innerHeight - (_wsInput.CursorPosition.y / window.devicePixelRatio);
-    const xPosition = _wsInput.CursorPosition.x / window.devicePixelRatio;
+export function ConvertInputAction(
+  _wsInput: WebsocketInputAction,
+): TouchFreeInputAction {
+  const yPosition = window.innerHeight -
+    (_wsInput.CursorPosition.y / window.devicePixelRatio);
+  const xPosition = _wsInput.CursorPosition.x / window.devicePixelRatio;
 
-    return new TouchFreeInputAction(
-        _wsInput.Timestamp,
-        FlagUtilities.GetInteractionTypeFromFlags(_wsInput.InteractionFlags),
-        FlagUtilities.GetHandTypeFromFlags(_wsInput.InteractionFlags),
-        FlagUtilities.GetChiralityFromFlags(_wsInput.InteractionFlags),
-        FlagUtilities.GetInputTypeFromFlags(_wsInput.InteractionFlags),
-        [xPosition, yPosition],
-        _wsInput.DistanceFromScreen,
-        _wsInput.ProgressToClick,
-    );
+  return new TouchFreeInputAction(
+    _wsInput.Timestamp,
+    FlagUtilities.GetInteractionTypeFromFlags(_wsInput.InteractionFlags),
+    FlagUtilities.GetHandTypeFromFlags(_wsInput.InteractionFlags),
+    FlagUtilities.GetChiralityFromFlags(_wsInput.InteractionFlags),
+    FlagUtilities.GetInputTypeFromFlags(_wsInput.InteractionFlags),
+    [xPosition, yPosition],
+    _wsInput.DistanceFromScreen,
+    _wsInput.ProgressToClick,
+  );
 }
 
 // Enum: HandChirality
 // LEFT - The left hand
 // RIGHT - The right hand
 export enum HandChirality {
-    LEFT,
-    RIGHT
+  LEFT,
+  RIGHT,
 }
 
 // Enum: HandType
 // PRIMARY - The first hand found
 // SECONDARY - The second hand found
 export enum HandType {
-    PRIMARY,
-    SECONDARY,
+  PRIMARY,
+  SECONDARY,
 }
 
 // Enum: InputType
@@ -91,11 +93,11 @@ export enum HandType {
 // MOVE - Used to move a cursor or to perform a 'Drag' after a DOWN
 // UP - Used to complete a 'Touch' or a 'Drag'
 export enum InputType {
-    NONE,
-    CANCEL,
-    DOWN,
-    MOVE,
-    UP,
+  NONE,
+  CANCEL,
+  DOWN,
+  MOVE,
+  UP,
 }
 
 // Enum: InteractionType
@@ -103,11 +105,11 @@ export enum InputType {
 // HOVER - The user must perform a HOVER gesture to 'Touch' by holding their hand still for a fixed time
 // PUSH - The user must perform a PUSH gesture to 'Touch' by pushing their hand toward the screen
 export enum InteractionType {
-    GRAB,
-    HOVER,
-    PUSH,
-    TOUCHPLANE,
-    VELOCITYSWIPE,
+  GRAB,
+  HOVER,
+  PUSH,
+  TOUCHPLANE,
+  VELOCITYSWIPE,
 }
 
 // Enum: TrackingServiceState
@@ -115,9 +117,9 @@ export enum InteractionType {
 // NO_CAMERA - The TouchFree service is connected to the tracking service but there is not a camera connected
 // CONNECTED - The TouchFree service is connected to the tracking service
 export enum TrackingServiceState {
-    UNAVAILABLE,
-    NO_CAMERA,
-    CONNECTED,
+  UNAVAILABLE,
+  NO_CAMERA,
+  CONNECTED,
 }
 
 // Enum: ConfigurationState
@@ -125,71 +127,93 @@ export enum TrackingServiceState {
 // LOADED - The TouchFree configuration has successfully been loaded
 // ERRORED - The TouchFree configuration errored on load
 export enum ConfigurationState {
-    NOT_LOADED,
-    LOADED,
-    ERRORED
+  NOT_LOADED,
+  LOADED,
+  ERRORED,
 }
 
 // Enum: BitmaskFlags
 // This is used to request any combination of the <HandChiralities>, <HandTypes>, <InputTypes>,
 // and <InteractionTypes> flags from the Service at once.
 export enum BitmaskFlags {
-    NONE = 0,
+  NONE = 0,
 
-    // HandChirality
-    LEFT = 1,
-    RIGHT = 2,
+  // HandChirality
+  LEFT = 1,
+  RIGHT = 2,
 
-    // Hand Type
-    PRIMARY = 4,
-    SECONDARY = 8,
+  // Hand Type
+  PRIMARY = 4,
+  SECONDARY = 8,
 
-    // Input Types
-    NONE_INPUT = 16,
-    CANCEL = 32,
-    DOWN = 64,
-    MOVE = 128,
-    UP = 256,
+  // Input Types
+  NONE_INPUT = 16,
+  CANCEL = 32,
+  DOWN = 64,
+  MOVE = 128,
+  UP = 256,
 
-    // Interaction Types
-    GRAB = 512,
-    HOVER = 1024,
-    PUSH = 2048,
-    TOUCHPLANE = 4096,
-    VELOCITYSWIPE = 8192,
+  // Interaction Types
+  GRAB = 512,
+  HOVER = 1024,
+  PUSH = 2048,
+  TOUCHPLANE = 4096,
+  VELOCITYSWIPE = 8192,
+  // Adding elements to this list is a breaking change, and should cause at
+  // least a minor iteration of the API version UNLESS adding them at the end
+}
 
-    // Adding elements to this list is a breaking change, and should cause at
-    // least a minor iteration of the API version UNLESS adding them at the end
+// Enum: TouchFreeEvent
+// ON_CONNECTED - Event dispatched when connecting to the TouchFree service
+// ON_TRACKING_SERVICE_STATE_CHANGE - Event dispatched when the connection between TouchFreeService and Ultraleap Tracking Service changes
+// HANDS_FOUND - Event dispatched when the first hand has started tracking
+// HANDS_LOST - Event dispatched when the last hand has stopped tracking
+// INPUT_ACTION - Event dispatched when any input action is received from the TouchFree service
+// INPUT_ACTION_OUTPUT - ??? (Never subscribed to?)
+// TRANSMIT_INPUT_ACTION_RAW - Event dispatched directly from the <InputActionManager> without any proxying
+// TRANSMIT_INPUT_ACTION - Event dispatched from the <InputActionManager> to each registered Plugin
+export enum TouchFreeEvent {
+  ON_CONNECTED = "OnConnected",
+  ON_TRACKING_SERVICE_STATE_CHANGE = "OnTrackingServiceStateChange",
+
+  HAND_FOUND = "HandFound",
+  HANDS_LOST = "HandsLost",
+
+  INPUT_ACTION = "InputAction",
+  INPUT_ACTION_OUTPUT = "InputActionOutput",
+
+  TRAMSIT_INPUT_ACTION_RAW = "TransmitInputActionRaw",
+  TRAMSIT_INPUT_ACTION = "TransmitInputAction",
 }
 
 // Class: WebsocketInputAction
 // The version of an InputAction received via the WebSocket. This must be converted into a
 // <TouchFreeInputAction> to be used by the Tooling and can be done so via ConvertInputAction.
 export class WebsocketInputAction {
-    // Variable: Timestamp
-    Timestamp: number;
-    // Variable: InteractionFlags
-    InteractionFlags: BitmaskFlags;
-    // Variable: CursorPosition
-    CursorPosition: any;
-    // Variable: DistanceFromScreen
-    DistanceFromScreen: number;
-    // Variable: ProgressToClick
-    ProgressToClick: number;
+  // Variable: Timestamp
+  Timestamp: number;
+  // Variable: InteractionFlags
+  InteractionFlags: BitmaskFlags;
+  // Variable: CursorPosition
+  CursorPosition: any;
+  // Variable: DistanceFromScreen
+  DistanceFromScreen: number;
+  // Variable: ProgressToClick
+  ProgressToClick: number;
 
-    constructor(
-        _timestamp: number,
-        _interactionFlags: BitmaskFlags,
-        _cursorPosition: any,
-        _distanceFromScreen: number,
-        _progressToClick: number,
-    ) {
-        this.Timestamp = _timestamp;
-        this.InteractionFlags = _interactionFlags;
-        this.CursorPosition = _cursorPosition;
-        this.DistanceFromScreen = _distanceFromScreen;
-        this.ProgressToClick = _progressToClick;
-    }
+  constructor(
+    _timestamp: number,
+    _interactionFlags: BitmaskFlags,
+    _cursorPosition: any,
+    _distanceFromScreen: number,
+    _progressToClick: number,
+  ) {
+    this.Timestamp = _timestamp;
+    this.InteractionFlags = _interactionFlags;
+    this.CursorPosition = _cursorPosition;
+    this.DistanceFromScreen = _distanceFromScreen;
+    this.ProgressToClick = _progressToClick;
+  }
 }
 
 // Class: HandFrame
@@ -240,172 +264,167 @@ export class RawBone
 // Class: FlagUtilities
 // A collection of Utilities to be used when working with <BitmaskFlags>.
 export class FlagUtilities {
-    // Group: Functions
+  // Group: Functions
 
-    // Function: GetInteractionFlags
-    // Used to convert a collection of interaction enums to flags for sending
-    // to the Service.
-    static GetInteractionFlags(
-        _interactionType: InteractionType,
-        _handType: HandType,
-        _chirality: HandChirality,
-        _inputType: InputType): BitmaskFlags {
-        let returnVal: BitmaskFlags = BitmaskFlags.NONE;
+  // Function: GetInteractionFlags
+  // Used to convert a collection of interaction enums to flags for sending
+  // to the Service.
+  static GetInteractionFlags(
+    _interactionType: InteractionType,
+    _handType: HandType,
+    _chirality: HandChirality,
+    _inputType: InputType,
+  ): BitmaskFlags {
+    let returnVal: BitmaskFlags = BitmaskFlags.NONE;
 
-        switch (_handType) {
-            case HandType.PRIMARY:
-                returnVal ^= BitmaskFlags.PRIMARY;
-                break;
+    switch (_handType) {
+      case HandType.PRIMARY:
+        returnVal ^= BitmaskFlags.PRIMARY;
+        break;
 
-            case HandType.SECONDARY:
-                returnVal ^= BitmaskFlags.SECONDARY;
-                break;
-        }
-
-        switch (_chirality) {
-            case HandChirality.LEFT:
-                returnVal ^= BitmaskFlags.LEFT;
-                break;
-
-            case HandChirality.RIGHT:
-                returnVal ^= BitmaskFlags.RIGHT;
-                break;
-        }
-
-        switch (_inputType) {
-            case InputType.NONE:
-                returnVal ^= BitmaskFlags.NONE_INPUT;
-                break;
-
-            case InputType.CANCEL:
-                returnVal ^= BitmaskFlags.CANCEL;
-                break;
-
-            case InputType.MOVE:
-                returnVal ^= BitmaskFlags.MOVE;
-                break;
-
-            case InputType.UP:
-                returnVal ^= BitmaskFlags.UP;
-                break;
-
-            case InputType.DOWN:
-                returnVal ^= BitmaskFlags.DOWN;
-                break;
-        }
-
-        switch (_interactionType) {
-            case InteractionType.PUSH:
-                returnVal ^= BitmaskFlags.PUSH;
-                break;
-
-            case InteractionType.HOVER:
-                returnVal ^= BitmaskFlags.HOVER;
-                break;
-
-            case InteractionType.GRAB:
-                returnVal ^= BitmaskFlags.GRAB;
-                break;
-
-            case InteractionType.TOUCHPLANE:
-                returnVal ^= BitmaskFlags.TOUCHPLANE;
-                break;
-
-            case InteractionType.VELOCITYSWIPE:
-                returnVal ^= BitmaskFlags.VELOCITYSWIPE;
-                break;
-        }
-
-        return returnVal;
+      case HandType.SECONDARY:
+        returnVal ^= BitmaskFlags.SECONDARY;
+        break;
     }
 
-    // Function: GetChiralityFromFlags
-    // Used to find which <HandChirality> _flags contains. Favours RIGHT if none or both are found.
-    static GetChiralityFromFlags(_flags: BitmaskFlags): HandChirality {
-        let chirality: HandChirality = HandChirality.RIGHT;
+    switch (_chirality) {
+      case HandChirality.LEFT:
+        returnVal ^= BitmaskFlags.LEFT;
+        break;
 
-        if (_flags & BitmaskFlags.RIGHT) {
-            chirality = HandChirality.RIGHT;
-        }
-        else if (_flags & BitmaskFlags.LEFT) {
-            chirality = HandChirality.LEFT;
-        }
-        else {
-            console.error("InputActionData missing: No Chirality found. Defaulting to 'RIGHT'");
-        }
-
-        return chirality;
+      case HandChirality.RIGHT:
+        returnVal ^= BitmaskFlags.RIGHT;
+        break;
     }
 
-    // Function: GetHandTypeFromFlags
-    // Used to find which <HandType> _flags contains. Favours PRIMARY if none or both are found.
-    static GetHandTypeFromFlags(_flags: BitmaskFlags): HandType {
-        let handType: HandType = HandType.PRIMARY;
+    switch (_inputType) {
+      case InputType.NONE:
+        returnVal ^= BitmaskFlags.NONE_INPUT;
+        break;
 
-        if (_flags & BitmaskFlags.PRIMARY) {
-            handType = HandType.PRIMARY;
-        }
-        else if (_flags & BitmaskFlags.SECONDARY) {
-            handType = HandType.SECONDARY;
-        }
-        else {
-            console.error("InputActionData missing: No HandData found. Defaulting to 'PRIMARY'");
-        }
+      case InputType.CANCEL:
+        returnVal ^= BitmaskFlags.CANCEL;
+        break;
 
-        return handType;
+      case InputType.MOVE:
+        returnVal ^= BitmaskFlags.MOVE;
+        break;
+
+      case InputType.UP:
+        returnVal ^= BitmaskFlags.UP;
+        break;
+
+      case InputType.DOWN:
+        returnVal ^= BitmaskFlags.DOWN;
+        break;
     }
 
-    // Function: GetInputTypeFromFlags
-    // Used to find which <InputType> _flags contains. Favours NONE if none are found.
-    static GetInputTypeFromFlags(_flags: BitmaskFlags): InputType {
-        let inputType: InputType = InputType.NONE;
+    switch (_interactionType) {
+      case InteractionType.PUSH:
+        returnVal ^= BitmaskFlags.PUSH;
+        break;
 
-        if (_flags & BitmaskFlags.NONE_INPUT) {
-            inputType = InputType.NONE;
-        }
-        else if (_flags & BitmaskFlags.CANCEL) {
-            inputType = InputType.CANCEL;
-        }
-        else if (_flags & BitmaskFlags.UP) {
-            inputType = InputType.UP;
-        }
-        else if (_flags & BitmaskFlags.DOWN) {
-            inputType = InputType.DOWN;
-        }
-        else if (_flags & BitmaskFlags.MOVE) {
-            inputType = InputType.MOVE;
-        }
-        else {
-            console.error("InputActionData missing: No InputType found. Defaulting to 'NONE'");
-        }
+      case InteractionType.HOVER:
+        returnVal ^= BitmaskFlags.HOVER;
+        break;
 
-        return inputType;
+      case InteractionType.GRAB:
+        returnVal ^= BitmaskFlags.GRAB;
+        break;
+
+      case InteractionType.TOUCHPLANE:
+        returnVal ^= BitmaskFlags.TOUCHPLANE;
+        break;
+
+      case InteractionType.VELOCITYSWIPE:
+        returnVal ^= BitmaskFlags.VELOCITYSWIPE;
+        break;
     }
 
-    // Function: GetInteractionTypeFromFlags
-    // Used to find which <InteractionType> _flags contains. Favours PUSH if none are found.
-    static GetInteractionTypeFromFlags(_flags: BitmaskFlags): InteractionType {
-        let interactionType: InteractionType = InteractionType.PUSH;
+    return returnVal;
+  }
 
-        if (_flags & BitmaskFlags.PUSH) {
-            interactionType = InteractionType.PUSH;
-        }
-        else if (_flags & BitmaskFlags.HOVER) {
-            interactionType = InteractionType.HOVER;
-        }
-        else if (_flags & BitmaskFlags.GRAB) {
-            interactionType = InteractionType.GRAB;
-        }
-        else if (_flags & BitmaskFlags.TOUCHPLANE) {
-            interactionType = InteractionType.TOUCHPLANE;
-        }
-        else if (_flags & BitmaskFlags.VELOCITYSWIPE) {
-            interactionType = InteractionType.VELOCITYSWIPE;
-        }
-        else {
-            console.error("InputActionData missing: No InteractionType found. Defaulting to 'PUSH'");
-        }
+  // Function: GetChiralityFromFlags
+  // Used to find which <HandChirality> _flags contains. Favours RIGHT if none or both are found.
+  static GetChiralityFromFlags(_flags: BitmaskFlags): HandChirality {
+    let chirality: HandChirality = HandChirality.RIGHT;
 
-        return interactionType;
+    if (_flags & BitmaskFlags.RIGHT) {
+      chirality = HandChirality.RIGHT;
+    } else if (_flags & BitmaskFlags.LEFT) {
+      chirality = HandChirality.LEFT;
+    } else {
+      console.error(
+        "InputActionData missing: No Chirality found. Defaulting to 'RIGHT'",
+      );
     }
+
+    return chirality;
+  }
+
+  // Function: GetHandTypeFromFlags
+  // Used to find which <HandType> _flags contains. Favours PRIMARY if none or both are found.
+  static GetHandTypeFromFlags(_flags: BitmaskFlags): HandType {
+    let handType: HandType = HandType.PRIMARY;
+
+    if (_flags & BitmaskFlags.PRIMARY) {
+      handType = HandType.PRIMARY;
+    } else if (_flags & BitmaskFlags.SECONDARY) {
+      handType = HandType.SECONDARY;
+    } else {
+      console.error(
+        "InputActionData missing: No HandData found. Defaulting to 'PRIMARY'",
+      );
+    }
+
+    return handType;
+  }
+
+  // Function: GetInputTypeFromFlags
+  // Used to find which <InputType> _flags contains. Favours NONE if none are found.
+  static GetInputTypeFromFlags(_flags: BitmaskFlags): InputType {
+    let inputType: InputType = InputType.NONE;
+
+    if (_flags & BitmaskFlags.NONE_INPUT) {
+      inputType = InputType.NONE;
+    } else if (_flags & BitmaskFlags.CANCEL) {
+      inputType = InputType.CANCEL;
+    } else if (_flags & BitmaskFlags.UP) {
+      inputType = InputType.UP;
+    } else if (_flags & BitmaskFlags.DOWN) {
+      inputType = InputType.DOWN;
+    } else if (_flags & BitmaskFlags.MOVE) {
+      inputType = InputType.MOVE;
+    } else {
+      console.error(
+        "InputActionData missing: No InputType found. Defaulting to 'NONE'",
+      );
+    }
+
+    return inputType;
+  }
+
+  // Function: GetInteractionTypeFromFlags
+  // Used to find which <InteractionType> _flags contains. Favours PUSH if none are found.
+  static GetInteractionTypeFromFlags(_flags: BitmaskFlags): InteractionType {
+    let interactionType: InteractionType = InteractionType.PUSH;
+
+    if (_flags & BitmaskFlags.PUSH) {
+      interactionType = InteractionType.PUSH;
+    } else if (_flags & BitmaskFlags.HOVER) {
+      interactionType = InteractionType.HOVER;
+    } else if (_flags & BitmaskFlags.GRAB) {
+      interactionType = InteractionType.GRAB;
+    } else if (_flags & BitmaskFlags.TOUCHPLANE) {
+      interactionType = InteractionType.TOUCHPLANE;
+    } else if (_flags & BitmaskFlags.VELOCITYSWIPE) {
+      interactionType = InteractionType.VELOCITYSWIPE;
+    } else {
+      console.error(
+        "InputActionData missing: No InteractionType found. Defaulting to 'PUSH'",
+      );
+    }
+
+    return interactionType;
+  }
 }

--- a/TF_Settings_Web/src/TouchFree/TouchFreeToolingTypes.ts
+++ b/TF_Settings_Web/src/TouchFree/TouchFreeToolingTypes.ts
@@ -3,87 +3,87 @@ import { Vector } from "./Configuration/ConfigurationTypes";
 // Class: VersionInfo
 // This class is used when comparing the <ApiVersion> of the Tooling and the Service.
 export class VersionInfo {
-  // Group: Variables
+    // Group: Variables
 
-  // Variable: ApiVersion
-  // The current API version of the Tooling.
-  public static readonly ApiVersion: string = "1.3.0";
+    // Variable: ApiVersion
+    // The current API version of the Tooling.
+    public static readonly ApiVersion: string = "1.3.0";
 
-  // Variable: API_HEADER_NAME
-  // The name of the header we wish the Service to compare our version with.
-  public static readonly API_HEADER_NAME: string = "TfApiVersion";
+    // Variable: API_HEADER_NAME
+    // The name of the header we wish the Service to compare our version with.
+    public static readonly API_HEADER_NAME: string = "TfApiVersion";
 }
 
 // Class: TouchFreeInputAction
 // A structure representing the Tooling verison of an InputAction. This is used to pass
 // key information relating to an action that has happened on the Service.
 export class TouchFreeInputAction {
-  Timestamp: number;
-  InteractionType: InteractionType;
-  HandType: HandType;
-  Chirality: HandChirality;
-  InputType: InputType;
-  CursorPosition: Array<number>;
-  DistanceFromScreen: number;
-  ProgressToClick: number;
+    Timestamp: number;
+    InteractionType: InteractionType;
+    HandType: HandType;
+    Chirality: HandChirality;
+    InputType: InputType;
+    CursorPosition: Array<number>;
+    DistanceFromScreen: number;
+    ProgressToClick: number;
 
-  constructor(
-    _timestamp: number,
-    _interactionType: InteractionType,
-    _handType: HandType,
-    _handChirality: HandChirality,
-    _inputType: InputType,
-    _cursorPosition: Array<number>,
-    _distanceFromScreen: number,
-    _progressToClick: number,
-  ) {
-    this.Timestamp = _timestamp;
-    this.InteractionType = _interactionType;
-    this.HandType = _handType;
-    this.Chirality = _handChirality;
-    this.InputType = _inputType;
-    this.CursorPosition = _cursorPosition;
-    this.DistanceFromScreen = _distanceFromScreen;
-    this.ProgressToClick = _progressToClick;
-  }
+    constructor(
+        _timestamp: number,
+        _interactionType: InteractionType,
+        _handType: HandType,
+        _handChirality: HandChirality,
+        _inputType: InputType,
+        _cursorPosition: Array<number>,
+        _distanceFromScreen: number,
+        _progressToClick: number,
+    ) {
+        this.Timestamp = _timestamp;
+        this.InteractionType = _interactionType;
+        this.HandType = _handType;
+        this.Chirality = _handChirality;
+        this.InputType = _inputType;
+        this.CursorPosition = _cursorPosition;
+        this.DistanceFromScreen = _distanceFromScreen;
+        this.ProgressToClick = _progressToClick;
+    }
 }
 
 // Function: ConvertInputAction
 // Used to translate the raw actions that come across the websocket (<WebsocketInputActions>) and
 // convert them into the Tooling-friendly <TouchFreeInputAction> format.
 export function ConvertInputAction(
-  _wsInput: WebsocketInputAction,
+    _wsInput: WebsocketInputAction,
 ): TouchFreeInputAction {
-  const yPosition = window.innerHeight -
-    (_wsInput.CursorPosition.y / window.devicePixelRatio);
-  const xPosition = _wsInput.CursorPosition.x / window.devicePixelRatio;
+    const yPosition = window.innerHeight -
+        (_wsInput.CursorPosition.y / window.devicePixelRatio);
+    const xPosition = _wsInput.CursorPosition.x / window.devicePixelRatio;
 
-  return new TouchFreeInputAction(
-    _wsInput.Timestamp,
-    FlagUtilities.GetInteractionTypeFromFlags(_wsInput.InteractionFlags),
-    FlagUtilities.GetHandTypeFromFlags(_wsInput.InteractionFlags),
-    FlagUtilities.GetChiralityFromFlags(_wsInput.InteractionFlags),
-    FlagUtilities.GetInputTypeFromFlags(_wsInput.InteractionFlags),
-    [xPosition, yPosition],
-    _wsInput.DistanceFromScreen,
-    _wsInput.ProgressToClick,
-  );
+    return new TouchFreeInputAction(
+        _wsInput.Timestamp,
+        FlagUtilities.GetInteractionTypeFromFlags(_wsInput.InteractionFlags),
+        FlagUtilities.GetHandTypeFromFlags(_wsInput.InteractionFlags),
+        FlagUtilities.GetChiralityFromFlags(_wsInput.InteractionFlags),
+        FlagUtilities.GetInputTypeFromFlags(_wsInput.InteractionFlags),
+        [xPosition, yPosition],
+        _wsInput.DistanceFromScreen,
+        _wsInput.ProgressToClick,
+    );
 }
 
 // Enum: HandChirality
 // LEFT - The left hand
 // RIGHT - The right hand
 export enum HandChirality {
-  LEFT,
-  RIGHT,
+    LEFT,
+    RIGHT,
 }
 
 // Enum: HandType
 // PRIMARY - The first hand found
 // SECONDARY - The second hand found
 export enum HandType {
-  PRIMARY,
-  SECONDARY,
+    PRIMARY,
+    SECONDARY,
 }
 
 // Enum: InputType
@@ -93,11 +93,11 @@ export enum HandType {
 // MOVE - Used to move a cursor or to perform a 'Drag' after a DOWN
 // UP - Used to complete a 'Touch' or a 'Drag'
 export enum InputType {
-  NONE,
-  CANCEL,
-  DOWN,
-  MOVE,
-  UP,
+    NONE,
+    CANCEL,
+    DOWN,
+    MOVE,
+    UP,
 }
 
 // Enum: InteractionType
@@ -105,11 +105,11 @@ export enum InputType {
 // HOVER - The user must perform a HOVER gesture to 'Touch' by holding their hand still for a fixed time
 // PUSH - The user must perform a PUSH gesture to 'Touch' by pushing their hand toward the screen
 export enum InteractionType {
-  GRAB,
-  HOVER,
-  PUSH,
-  TOUCHPLANE,
-  VELOCITYSWIPE,
+    GRAB,
+    HOVER,
+    PUSH,
+    TOUCHPLANE,
+    VELOCITYSWIPE,
 }
 
 // Enum: TrackingServiceState
@@ -117,9 +117,9 @@ export enum InteractionType {
 // NO_CAMERA - The TouchFree service is connected to the tracking service but there is not a camera connected
 // CONNECTED - The TouchFree service is connected to the tracking service
 export enum TrackingServiceState {
-  UNAVAILABLE,
-  NO_CAMERA,
-  CONNECTED,
+    UNAVAILABLE,
+    NO_CAMERA,
+    CONNECTED,
 }
 
 // Enum: ConfigurationState
@@ -127,40 +127,40 @@ export enum TrackingServiceState {
 // LOADED - The TouchFree configuration has successfully been loaded
 // ERRORED - The TouchFree configuration errored on load
 export enum ConfigurationState {
-  NOT_LOADED,
-  LOADED,
-  ERRORED,
+    NOT_LOADED,
+    LOADED,
+    ERRORED,
 }
 
 // Enum: BitmaskFlags
 // This is used to request any combination of the <HandChiralities>, <HandTypes>, <InputTypes>,
 // and <InteractionTypes> flags from the Service at once.
 export enum BitmaskFlags {
-  NONE = 0,
+    NONE = 0,
 
-  // HandChirality
-  LEFT = 1,
-  RIGHT = 2,
+    // HandChirality
+    LEFT = 1,
+    RIGHT = 2,
 
-  // Hand Type
-  PRIMARY = 4,
-  SECONDARY = 8,
+    // Hand Type
+    PRIMARY = 4,
+    SECONDARY = 8,
 
-  // Input Types
-  NONE_INPUT = 16,
-  CANCEL = 32,
-  DOWN = 64,
-  MOVE = 128,
-  UP = 256,
+    // Input Types
+    NONE_INPUT = 16,
+    CANCEL = 32,
+    DOWN = 64,
+    MOVE = 128,
+    UP = 256,
 
-  // Interaction Types
-  GRAB = 512,
-  HOVER = 1024,
-  PUSH = 2048,
-  TOUCHPLANE = 4096,
-  VELOCITYSWIPE = 8192,
-  // Adding elements to this list is a breaking change, and should cause at
-  // least a minor iteration of the API version UNLESS adding them at the end
+    // Interaction Types
+    GRAB = 512,
+    HOVER = 1024,
+    PUSH = 2048,
+    TOUCHPLANE = 4096,
+    VELOCITYSWIPE = 8192,
+    // Adding elements to this list is a breaking change, and should cause at
+    // least a minor iteration of the API version UNLESS adding them at the end
 }
 
 // Enum: TouchFreeEvent
@@ -173,78 +173,74 @@ export enum BitmaskFlags {
 // TRANSMIT_INPUT_ACTION_RAW - Event dispatched directly from the <InputActionManager> without any proxying
 // TRANSMIT_INPUT_ACTION - Event dispatched from the <InputActionManager> to each registered Plugin
 export enum TouchFreeEvent {
-  ON_CONNECTED = "OnConnected",
-  ON_TRACKING_SERVICE_STATE_CHANGE = "OnTrackingServiceStateChange",
+    ON_CONNECTED = "OnConnected",
+    ON_TRACKING_SERVICE_STATE_CHANGE = "OnTrackingServiceStateChange",
 
-  HAND_FOUND = "HandFound",
-  HANDS_LOST = "HandsLost",
+    HAND_FOUND = "HandFound",
+    HANDS_LOST = "HandsLost",
 
-  INPUT_ACTION = "InputAction",
-  INPUT_ACTION_OUTPUT = "InputActionOutput",
+    INPUT_ACTION = "InputAction",
+    INPUT_ACTION_OUTPUT = "InputActionOutput",
 
-  TRAMSIT_INPUT_ACTION_RAW = "TransmitInputActionRaw",
-  TRAMSIT_INPUT_ACTION = "TransmitInputAction",
+    TRAMSIT_INPUT_ACTION_RAW = "TransmitInputActionRaw",
+    TRAMSIT_INPUT_ACTION = "TransmitInputAction",
 }
 
 // Class: WebsocketInputAction
 // The version of an InputAction received via the WebSocket. This must be converted into a
 // <TouchFreeInputAction> to be used by the Tooling and can be done so via ConvertInputAction.
 export class WebsocketInputAction {
-  // Variable: Timestamp
-  Timestamp: number;
-  // Variable: InteractionFlags
-  InteractionFlags: BitmaskFlags;
-  // Variable: CursorPosition
-  CursorPosition: any;
-  // Variable: DistanceFromScreen
-  DistanceFromScreen: number;
-  // Variable: ProgressToClick
-  ProgressToClick: number;
+    // Variable: Timestamp
+    Timestamp: number;
+    // Variable: InteractionFlags
+    InteractionFlags: BitmaskFlags;
+    // Variable: CursorPosition
+    CursorPosition: any;
+    // Variable: DistanceFromScreen
+    DistanceFromScreen: number;
+    // Variable: ProgressToClick
+    ProgressToClick: number;
 
-  constructor(
-    _timestamp: number,
-    _interactionFlags: BitmaskFlags,
-    _cursorPosition: any,
-    _distanceFromScreen: number,
-    _progressToClick: number,
-  ) {
-    this.Timestamp = _timestamp;
-    this.InteractionFlags = _interactionFlags;
-    this.CursorPosition = _cursorPosition;
-    this.DistanceFromScreen = _distanceFromScreen;
-    this.ProgressToClick = _progressToClick;
-  }
+    constructor(
+        _timestamp: number,
+        _interactionFlags: BitmaskFlags,
+        _cursorPosition: any,
+        _distanceFromScreen: number,
+        _progressToClick: number,
+    ) {
+        this.Timestamp = _timestamp;
+        this.InteractionFlags = _interactionFlags;
+        this.CursorPosition = _cursorPosition;
+        this.DistanceFromScreen = _distanceFromScreen;
+        this.ProgressToClick = _progressToClick;
+    }
 }
 
 // Class: HandFrame
 // A frame of hand data
-export class HandFrame
-{
+export class HandFrame {
     Hands: RawHand[] = [];
 }
 
 // Class: RawHand
 // The raw position data for a hand
-export class RawHand
-{
+export class RawHand {
     CurrentPrimary: boolean = false;
     Fingers: RawFinger[] = [];
     WristWidth: number = 0;
-    WristPosition: Vector = {X:0,Y:0,Z:0};
+    WristPosition: Vector = { X: 0, Y: 0, Z: 0 };
 }
 
 // Class: RawFinger
 // The raw position data for a finger of a hand
-export class RawFinger
-{
+export class RawFinger {
     Bones: RawBone[] = []
     Type: FingerType = FingerType.TYPE_UNKNOWN;
 }
 
 // Enum: FingerType
 // What finger on a hand a finger is.
-export enum FingerType
-{
+export enum FingerType {
     TYPE_THUMB = 0,
     TYPE_INDEX = 1,
     TYPE_MIDDLE = 2,
@@ -255,176 +251,175 @@ export enum FingerType
 
 // Class: RawFinger
 // The raw position data for a bone in a finger
-export class RawBone
-{
-    NextJoint: Vector = {X:0,Y:0,Z:0};
-    PrevJoint: Vector = {X:0,Y:0,Z:0};
+export class RawBone {
+    NextJoint: Vector = { X: 0, Y: 0, Z: 0 };
+    PrevJoint: Vector = { X: 0, Y: 0, Z: 0 };
 }
 
 // Class: FlagUtilities
 // A collection of Utilities to be used when working with <BitmaskFlags>.
 export class FlagUtilities {
-  // Group: Functions
+    // Group: Functions
 
-  // Function: GetInteractionFlags
-  // Used to convert a collection of interaction enums to flags for sending
-  // to the Service.
-  static GetInteractionFlags(
-    _interactionType: InteractionType,
-    _handType: HandType,
-    _chirality: HandChirality,
-    _inputType: InputType,
-  ): BitmaskFlags {
-    let returnVal: BitmaskFlags = BitmaskFlags.NONE;
+    // Function: GetInteractionFlags
+    // Used to convert a collection of interaction enums to flags for sending
+    // to the Service.
+    static GetInteractionFlags(
+        _interactionType: InteractionType,
+        _handType: HandType,
+        _chirality: HandChirality,
+        _inputType: InputType,
+    ): BitmaskFlags {
+        let returnVal: BitmaskFlags = BitmaskFlags.NONE;
 
-    switch (_handType) {
-      case HandType.PRIMARY:
-        returnVal ^= BitmaskFlags.PRIMARY;
-        break;
+        switch (_handType) {
+            case HandType.PRIMARY:
+                returnVal ^= BitmaskFlags.PRIMARY;
+                break;
 
-      case HandType.SECONDARY:
-        returnVal ^= BitmaskFlags.SECONDARY;
-        break;
+            case HandType.SECONDARY:
+                returnVal ^= BitmaskFlags.SECONDARY;
+                break;
+        }
+
+        switch (_chirality) {
+            case HandChirality.LEFT:
+                returnVal ^= BitmaskFlags.LEFT;
+                break;
+
+            case HandChirality.RIGHT:
+                returnVal ^= BitmaskFlags.RIGHT;
+                break;
+        }
+
+        switch (_inputType) {
+            case InputType.NONE:
+                returnVal ^= BitmaskFlags.NONE_INPUT;
+                break;
+
+            case InputType.CANCEL:
+                returnVal ^= BitmaskFlags.CANCEL;
+                break;
+
+            case InputType.MOVE:
+                returnVal ^= BitmaskFlags.MOVE;
+                break;
+
+            case InputType.UP:
+                returnVal ^= BitmaskFlags.UP;
+                break;
+
+            case InputType.DOWN:
+                returnVal ^= BitmaskFlags.DOWN;
+                break;
+        }
+
+        switch (_interactionType) {
+            case InteractionType.PUSH:
+                returnVal ^= BitmaskFlags.PUSH;
+                break;
+
+            case InteractionType.HOVER:
+                returnVal ^= BitmaskFlags.HOVER;
+                break;
+
+            case InteractionType.GRAB:
+                returnVal ^= BitmaskFlags.GRAB;
+                break;
+
+            case InteractionType.TOUCHPLANE:
+                returnVal ^= BitmaskFlags.TOUCHPLANE;
+                break;
+
+            case InteractionType.VELOCITYSWIPE:
+                returnVal ^= BitmaskFlags.VELOCITYSWIPE;
+                break;
+        }
+
+        return returnVal;
     }
 
-    switch (_chirality) {
-      case HandChirality.LEFT:
-        returnVal ^= BitmaskFlags.LEFT;
-        break;
+    // Function: GetChiralityFromFlags
+    // Used to find which <HandChirality> _flags contains. Favours RIGHT if none or both are found.
+    static GetChiralityFromFlags(_flags: BitmaskFlags): HandChirality {
+        let chirality: HandChirality = HandChirality.RIGHT;
 
-      case HandChirality.RIGHT:
-        returnVal ^= BitmaskFlags.RIGHT;
-        break;
+        if (_flags & BitmaskFlags.RIGHT) {
+            chirality = HandChirality.RIGHT;
+        } else if (_flags & BitmaskFlags.LEFT) {
+            chirality = HandChirality.LEFT;
+        } else {
+            console.error(
+                "InputActionData missing: No Chirality found. Defaulting to 'RIGHT'",
+            );
+        }
+
+        return chirality;
     }
 
-    switch (_inputType) {
-      case InputType.NONE:
-        returnVal ^= BitmaskFlags.NONE_INPUT;
-        break;
+    // Function: GetHandTypeFromFlags
+    // Used to find which <HandType> _flags contains. Favours PRIMARY if none or both are found.
+    static GetHandTypeFromFlags(_flags: BitmaskFlags): HandType {
+        let handType: HandType = HandType.PRIMARY;
 
-      case InputType.CANCEL:
-        returnVal ^= BitmaskFlags.CANCEL;
-        break;
+        if (_flags & BitmaskFlags.PRIMARY) {
+            handType = HandType.PRIMARY;
+        } else if (_flags & BitmaskFlags.SECONDARY) {
+            handType = HandType.SECONDARY;
+        } else {
+            console.error(
+                "InputActionData missing: No HandData found. Defaulting to 'PRIMARY'",
+            );
+        }
 
-      case InputType.MOVE:
-        returnVal ^= BitmaskFlags.MOVE;
-        break;
-
-      case InputType.UP:
-        returnVal ^= BitmaskFlags.UP;
-        break;
-
-      case InputType.DOWN:
-        returnVal ^= BitmaskFlags.DOWN;
-        break;
+        return handType;
     }
 
-    switch (_interactionType) {
-      case InteractionType.PUSH:
-        returnVal ^= BitmaskFlags.PUSH;
-        break;
+    // Function: GetInputTypeFromFlags
+    // Used to find which <InputType> _flags contains. Favours NONE if none are found.
+    static GetInputTypeFromFlags(_flags: BitmaskFlags): InputType {
+        let inputType: InputType = InputType.NONE;
 
-      case InteractionType.HOVER:
-        returnVal ^= BitmaskFlags.HOVER;
-        break;
+        if (_flags & BitmaskFlags.NONE_INPUT) {
+            inputType = InputType.NONE;
+        } else if (_flags & BitmaskFlags.CANCEL) {
+            inputType = InputType.CANCEL;
+        } else if (_flags & BitmaskFlags.UP) {
+            inputType = InputType.UP;
+        } else if (_flags & BitmaskFlags.DOWN) {
+            inputType = InputType.DOWN;
+        } else if (_flags & BitmaskFlags.MOVE) {
+            inputType = InputType.MOVE;
+        } else {
+            console.error(
+                "InputActionData missing: No InputType found. Defaulting to 'NONE'",
+            );
+        }
 
-      case InteractionType.GRAB:
-        returnVal ^= BitmaskFlags.GRAB;
-        break;
-
-      case InteractionType.TOUCHPLANE:
-        returnVal ^= BitmaskFlags.TOUCHPLANE;
-        break;
-
-      case InteractionType.VELOCITYSWIPE:
-        returnVal ^= BitmaskFlags.VELOCITYSWIPE;
-        break;
+        return inputType;
     }
 
-    return returnVal;
-  }
+    // Function: GetInteractionTypeFromFlags
+    // Used to find which <InteractionType> _flags contains. Favours PUSH if none are found.
+    static GetInteractionTypeFromFlags(_flags: BitmaskFlags): InteractionType {
+        let interactionType: InteractionType = InteractionType.PUSH;
 
-  // Function: GetChiralityFromFlags
-  // Used to find which <HandChirality> _flags contains. Favours RIGHT if none or both are found.
-  static GetChiralityFromFlags(_flags: BitmaskFlags): HandChirality {
-    let chirality: HandChirality = HandChirality.RIGHT;
+        if (_flags & BitmaskFlags.PUSH) {
+            interactionType = InteractionType.PUSH;
+        } else if (_flags & BitmaskFlags.HOVER) {
+            interactionType = InteractionType.HOVER;
+        } else if (_flags & BitmaskFlags.GRAB) {
+            interactionType = InteractionType.GRAB;
+        } else if (_flags & BitmaskFlags.TOUCHPLANE) {
+            interactionType = InteractionType.TOUCHPLANE;
+        } else if (_flags & BitmaskFlags.VELOCITYSWIPE) {
+            interactionType = InteractionType.VELOCITYSWIPE;
+        } else {
+            console.error(
+                "InputActionData missing: No InteractionType found. Defaulting to 'PUSH'",
+            );
+        }
 
-    if (_flags & BitmaskFlags.RIGHT) {
-      chirality = HandChirality.RIGHT;
-    } else if (_flags & BitmaskFlags.LEFT) {
-      chirality = HandChirality.LEFT;
-    } else {
-      console.error(
-        "InputActionData missing: No Chirality found. Defaulting to 'RIGHT'",
-      );
+        return interactionType;
     }
-
-    return chirality;
-  }
-
-  // Function: GetHandTypeFromFlags
-  // Used to find which <HandType> _flags contains. Favours PRIMARY if none or both are found.
-  static GetHandTypeFromFlags(_flags: BitmaskFlags): HandType {
-    let handType: HandType = HandType.PRIMARY;
-
-    if (_flags & BitmaskFlags.PRIMARY) {
-      handType = HandType.PRIMARY;
-    } else if (_flags & BitmaskFlags.SECONDARY) {
-      handType = HandType.SECONDARY;
-    } else {
-      console.error(
-        "InputActionData missing: No HandData found. Defaulting to 'PRIMARY'",
-      );
-    }
-
-    return handType;
-  }
-
-  // Function: GetInputTypeFromFlags
-  // Used to find which <InputType> _flags contains. Favours NONE if none are found.
-  static GetInputTypeFromFlags(_flags: BitmaskFlags): InputType {
-    let inputType: InputType = InputType.NONE;
-
-    if (_flags & BitmaskFlags.NONE_INPUT) {
-      inputType = InputType.NONE;
-    } else if (_flags & BitmaskFlags.CANCEL) {
-      inputType = InputType.CANCEL;
-    } else if (_flags & BitmaskFlags.UP) {
-      inputType = InputType.UP;
-    } else if (_flags & BitmaskFlags.DOWN) {
-      inputType = InputType.DOWN;
-    } else if (_flags & BitmaskFlags.MOVE) {
-      inputType = InputType.MOVE;
-    } else {
-      console.error(
-        "InputActionData missing: No InputType found. Defaulting to 'NONE'",
-      );
-    }
-
-    return inputType;
-  }
-
-  // Function: GetInteractionTypeFromFlags
-  // Used to find which <InteractionType> _flags contains. Favours PUSH if none are found.
-  static GetInteractionTypeFromFlags(_flags: BitmaskFlags): InteractionType {
-    let interactionType: InteractionType = InteractionType.PUSH;
-
-    if (_flags & BitmaskFlags.PUSH) {
-      interactionType = InteractionType.PUSH;
-    } else if (_flags & BitmaskFlags.HOVER) {
-      interactionType = InteractionType.HOVER;
-    } else if (_flags & BitmaskFlags.GRAB) {
-      interactionType = InteractionType.GRAB;
-    } else if (_flags & BitmaskFlags.TOUCHPLANE) {
-      interactionType = InteractionType.TOUCHPLANE;
-    } else if (_flags & BitmaskFlags.VELOCITYSWIPE) {
-      interactionType = InteractionType.VELOCITYSWIPE;
-    } else {
-      console.error(
-        "InputActionData missing: No InteractionType found. Defaulting to 'PUSH'",
-      );
-    }
-
-    return interactionType;
-  }
 }

--- a/TF_Tooling_Web/src/Connection/ConnectionManager.ts
+++ b/TF_Tooling_Web/src/Connection/ConnectionManager.ts
@@ -1,4 +1,4 @@
-import { TouchFreeEvent } from "../TouchFreeToolingTypes";
+import { TouchFreeEvent, TrackingServiceState } from "../TouchFreeToolingTypes";
 import { MessageReceiver } from "./MessageReceiver";
 import { ServiceConnection } from "./ServiceConnection";
 import { HandPresenceState, ServiceStatus } from "./TouchFreeServiceTypes";
@@ -7,131 +7,136 @@ import { HandPresenceState, ServiceStatus } from "./TouchFreeServiceTypes";
 // This Class manages the connection to the Service. It provides static variables
 // for ease of use and is a Singleton to allow for easy referencing.
 export class ConnectionManager extends EventTarget {
-  // Group: Events
+    // Group: Events
 
-  // Event: OnConnected
-  // An event which is emitted when <Connect> is called.
-  //
-  // Instead of adding listeners to this event, use <AddConnectionListener> to ensure that your
-  // function is invoked if the connection has already been made by the time your class runs.
+    // Event: OnConnected
+    // An event which is emitted when <Connect> is called.
+    //
+    // Instead of adding listeners to this event, use <AddConnectionListener> to ensure that your
+    // function is invoked if the connection has already been made by the time your class runs.
 
-  // Group: Variables
+    // Group: Variables
 
-  // Variable: currentServiceConnection
-  // The private reference to the currently managed <ServiceConnection>.
-  private static currentServiceConnection: ServiceConnection | null;
+    // Variable: currentServiceConnection
+    // The private reference to the currently managed <ServiceConnection>.
+    private static currentServiceConnection: ServiceConnection | null;
 
-  // Variable: serviceConnection
-  // The public get-only reference to the currently managed <ServiceConnection>.
-  public static serviceConnection(): ServiceConnection | null {
-    return ConnectionManager.currentServiceConnection;
+    // Variable: serviceConnection
+    // The public get-only reference to the currently managed <ServiceConnection>.
+    public static serviceConnection(): ServiceConnection | null {
+        return ConnectionManager.currentServiceConnection;
     }
 
-  // Variable: messageReceiver
-  // A reference to the receiver that handles destribution of data received via the <currentServiceConnection> if connected.
-  public static messageReceiver: MessageReceiver;
+    // Variable: messageReceiver
+    // A reference to the receiver that handles destribution of data received via the <currentServiceConnection> if connected.
+    public static messageReceiver: MessageReceiver;
 
-  // Variable: instance
-  // The instance of the singleton for referencing the events transmitted
-  public static instance: ConnectionManager;
+    // Variable: instance
+    // The instance of the singleton for referencing the events transmitted
+    public static instance: ConnectionManager;
 
-  // Variable: iPAddress
-  // The IP Address that will be used in the <ServiceConnection> to connect to the target
-  // WebSocket. This value is settable in the Inspector.
-  static iPAddress: string = "127.0.0.1";
+    // Variable: iPAddress
+    // The IP Address that will be used in the <ServiceConnection> to connect to the target
+    // WebSocket. This value is settable in the Inspector.
+    static iPAddress: string = "127.0.0.1";
 
-  // Variable: port
-  // The Port that will be used in the <ServiceConnection> to connect to the target WebSocket.
-  // This value is settable in the Inspector.
-  static port: string = "9739";
+    // Variable: port
+    // The Port that will be used in the <ServiceConnection> to connect to the target WebSocket.
+    // This value is settable in the Inspector.
+    static port: string = "9739";
 
-  // Variable: currentHandPresence
-  // Private reference to the current hand presense state
-  private static currentHandPresence: HandPresenceState =
-    HandPresenceState.HANDS_LOST;
+    // Variable: currentHandPresence
+    // Private reference to the current hand presense state
+    private static currentHandPresence: HandPresenceState =
+        HandPresenceState.HANDS_LOST;
 
-  // Group: Functions
+    // Group: Functions
 
-  // Function: init
-  // Used to begin the connection. Creates the required <MessageReceiver>.
-  // Also attempts to immediately <Connect> to a WebSocket.
-  public static init() {
-    ConnectionManager.messageReceiver = new MessageReceiver();
-    ConnectionManager.instance = new ConnectionManager();
-    ConnectionManager.Connect();
-  }
-
-  // Function: AddConnectionListener
-  // Used to both add the _onConnectFunc action to the listeners of <OnConnected>
-  // as well as auto-call the _onConnectFunc if a connection is already made.
-  public static AddConnectionListener(_onConnectFunc: () => void): void {
-    ConnectionManager.instance.addEventListener(TouchFreeEvent.ON_CONNECTED, _onConnectFunc);
-
-    if (
-      ConnectionManager.currentServiceConnection !== null &&
-      ConnectionManager.currentServiceConnection.webSocket.readyState ===
-        WebSocket.OPEN
-    ) {
-      _onConnectFunc();
-    }
-  }
-
-  // Function: Connect
-  // Creates a new <ServiceConnection> using <iPAddress> and <port>.
-  // Also invokes <OnConnected> on all listeners.
-  public static Connect(): void {
-    ConnectionManager.currentServiceConnection = new ServiceConnection(
-      ConnectionManager.iPAddress,
-      ConnectionManager.port,
-    );
-  }
-
-  // Function: HandleHandPresenceEvent
-  // Called by the <MessageReciever> to pass HandPresence events via the <HandFound> and
-  // <HandsLost> events on this class
-  public static HandleHandPresenceEvent(_state: HandPresenceState): void {
-    ConnectionManager.currentHandPresence = _state;
-
-    let handPresenceEvent: Event;
-
-    if (_state === HandPresenceState.HAND_FOUND) {
-      handPresenceEvent = new Event(TouchFreeEvent.HAND_FOUND);
-    } else {
-      handPresenceEvent = new Event(TouchFreeEvent.HANDS_LOST);
+    // Function: init
+    // Used to begin the connection. Creates the required <MessageReceiver>.
+    // Also attempts to immediately <Connect> to a WebSocket.
+    public static init() {
+        ConnectionManager.messageReceiver = new MessageReceiver();
+        ConnectionManager.instance = new ConnectionManager();
+        ConnectionManager.Connect();
     }
 
-    ConnectionManager.instance.dispatchEvent(handPresenceEvent);
-  }
+    // Function: AddConnectionListener
+    // Used to both add the _onConnectFunc action to the listeners of <OnConnected>
+    // as well as auto-call the _onConnectFunc if a connection is already made.
+    public static AddConnectionListener(_onConnectFunc: () => void): void {
+        ConnectionManager.instance.addEventListener(TouchFreeEvent.ON_CONNECTED, _onConnectFunc);
 
-  // Function: Disconnect
-  // Disconnects <currentServiceConnection> if it is connected to a WebSocket and
-  // sets it to null.
-  public static Disconnect(): void {
-    if (ConnectionManager.currentServiceConnection !== null) {
-      ConnectionManager.currentServiceConnection.Disconnect();
-      ConnectionManager.currentServiceConnection = null;
-    }
-  }
-
-  // Function: RequestServiceStatus
-  // Used to request information from the Service via the <ConnectionManager>. Provides an asynchronous
-  // <ServiceStatus> via the _callback parameter.
-  //
-  // If your _callback requires context it should be bound to that context via .bind()
-  public static RequestServiceStatus(
-    _callback: (detail: ServiceStatus) => void,
-  ): void {
-    if (_callback === null) {
-      console.error("Request failed. This is due to a missing callback");
-      return;
+        if (
+            ConnectionManager.currentServiceConnection !== null &&
+            ConnectionManager.currentServiceConnection.webSocket.readyState ===
+            WebSocket.OPEN
+        ) {
+            _onConnectFunc();
+        }
     }
 
-    ConnectionManager.serviceConnection()?.RequestServiceStatus(_callback);
-  }
+    public static AddServiceStatusListener(_serviceStatusFunc: (serviceStatus: TrackingServiceState) => void): void {
+        ConnectionManager.instance.addEventListener(TouchFreeEvent.ON_TRACKING_SERVICE_STATE_CHANGE,
+            ((evt: CustomEvent<TrackingServiceState>) => { _serviceStatusFunc(evt.detail) }) as EventListener);
+    }
 
-  // Function: RequestServiceStatus
-  // Function to get the current hand presense state
-  public static GetCurrentHandPresence(): HandPresenceState {
-    return ConnectionManager.currentHandPresence;
-  }
+    // Function: Connect
+    // Creates a new <ServiceConnection> using <iPAddress> and <port>.
+    // Also invokes <OnConnected> on all listeners.
+    public static Connect(): void {
+        ConnectionManager.currentServiceConnection = new ServiceConnection(
+            ConnectionManager.iPAddress,
+            ConnectionManager.port,
+        );
+    }
+
+    // Function: HandleHandPresenceEvent
+    // Called by the <MessageReciever> to pass HandPresence events via the <HandFound> and
+    // <HandsLost> events on this class
+    public static HandleHandPresenceEvent(_state: HandPresenceState): void {
+        ConnectionManager.currentHandPresence = _state;
+
+        let handPresenceEvent: Event;
+
+        if (_state === HandPresenceState.HAND_FOUND) {
+            handPresenceEvent = new Event(TouchFreeEvent.HAND_FOUND);
+        } else {
+            handPresenceEvent = new Event(TouchFreeEvent.HANDS_LOST);
+        }
+
+        ConnectionManager.instance.dispatchEvent(handPresenceEvent);
+    }
+
+    // Function: Disconnect
+    // Disconnects <currentServiceConnection> if it is connected to a WebSocket and
+    // sets it to null.
+    public static Disconnect(): void {
+        if (ConnectionManager.currentServiceConnection !== null) {
+            ConnectionManager.currentServiceConnection.Disconnect();
+            ConnectionManager.currentServiceConnection = null;
+        }
+    }
+
+    // Function: RequestServiceStatus
+    // Used to request information from the Service via the <ConnectionManager>. Provides an asynchronous
+    // <ServiceStatus> via the _callback parameter.
+    //
+    // If your _callback requires context it should be bound to that context via .bind()
+    public static RequestServiceStatus(
+        _callback: (detail: ServiceStatus) => void,
+    ): void {
+        if (_callback === null) {
+            console.error("Request failed. This is due to a missing callback");
+            return;
+        }
+
+        ConnectionManager.serviceConnection()?.RequestServiceStatus(_callback);
+    }
+
+    // Function: RequestServiceStatus
+    // Function to get the current hand presense state
+    public static GetCurrentHandPresence(): HandPresenceState {
+        return ConnectionManager.currentHandPresence;
+    }
 }

--- a/TF_Tooling_Web/src/Connection/ConnectionManager.ts
+++ b/TF_Tooling_Web/src/Connection/ConnectionManager.ts
@@ -1,4 +1,4 @@
-
+import { TouchFreeEvent } from "../TouchFreeToolingTypes";
 import { MessageReceiver } from "./MessageReceiver";
 import { ServiceConnection } from "./ServiceConnection";
 import { HandPresenceState, ServiceStatus } from "./TouchFreeServiceTypes";
@@ -7,125 +7,131 @@ import { HandPresenceState, ServiceStatus } from "./TouchFreeServiceTypes";
 // This Class manages the connection to the Service. It provides static variables
 // for ease of use and is a Singleton to allow for easy referencing.
 export class ConnectionManager extends EventTarget {
+  // Group: Events
 
-    // Group: Events
+  // Event: OnConnected
+  // An event which is emitted when <Connect> is called.
+  //
+  // Instead of adding listeners to this event, use <AddConnectionListener> to ensure that your
+  // function is invoked if the connection has already been made by the time your class runs.
 
-    // Event: OnConnected
-    // An event which is emitted when <Connect> is called.
-    //
-    // Instead of adding listeners to this event, use <AddConnectionListener> to ensure that your
-    // function is invoked if the connection has already been made by the time your class runs.
+  // Group: Variables
 
-    // Group: Variables
+  // Variable: currentServiceConnection
+  // The private reference to the currently managed <ServiceConnection>.
+  private static currentServiceConnection: ServiceConnection | null;
 
-    // Variable: currentServiceConnection
-    // The private reference to the currently managed <ServiceConnection>.
-    private static currentServiceConnection: ServiceConnection | null;
-
-    // Variable: serviceConnection
-    // The public get-only reference to the currently managed <ServiceConnection>.
-    public static serviceConnection(): ServiceConnection | null {
-        return ConnectionManager.currentServiceConnection;
-    };
-
-    // Variable: messageReceiver
-    // A reference to the receiver that handles destribution of data received via the <currentServiceConnection> if connected.
-    public static messageReceiver: MessageReceiver;
-
-    // Variable: instance
-    // The instance of the singleton for referencing the events transmitted
-    public static instance: ConnectionManager;
-
-    // Variable: iPAddress
-    // The IP Address that will be used in the <ServiceConnection> to connect to the target
-    // WebSocket. This value is settable in the Inspector.
-    static iPAddress: string = "127.0.0.1";
-
-    // Variable: port
-    // The Port that will be used in the <ServiceConnection> to connect to the target WebSocket.
-    // This value is settable in the Inspector.
-    static port: string = "9739";
-
-    // Variable: currentHandPresence
-    // Private reference to the current hand presense state
-    private static currentHandPresence: HandPresenceState = HandPresenceState.HANDS_LOST;
-
-    // Group: Functions
-
-    // Function: init
-    // Used to begin the connection. Creates the required <MessageReceiver>.
-    // Also attempts to immediately <Connect> to a WebSocket.
-    public static init() {
-        ConnectionManager.messageReceiver = new MessageReceiver();
-        ConnectionManager.instance = new ConnectionManager();
-        ConnectionManager.Connect();
+  // Variable: serviceConnection
+  // The public get-only reference to the currently managed <ServiceConnection>.
+  public static serviceConnection(): ServiceConnection | null {
+    return ConnectionManager.currentServiceConnection;
     }
 
-    // Function: AddConnectionListener
-    // Used to both add the _onConnectFunc action to the listeners of <OnConnected>
-    // as well as auto-call the _onConnectFunc if a connection is already made.
-    public static AddConnectionListener(_onConnectFunc: () => void): void {
-        ConnectionManager.instance.addEventListener('OnConnected', _onConnectFunc);
+  // Variable: messageReceiver
+  // A reference to the receiver that handles destribution of data received via the <currentServiceConnection> if connected.
+  public static messageReceiver: MessageReceiver;
 
-        if (ConnectionManager.currentServiceConnection !== null &&
-            ConnectionManager.currentServiceConnection.webSocket.readyState === WebSocket.OPEN) {
-            _onConnectFunc();
-        }
+  // Variable: instance
+  // The instance of the singleton for referencing the events transmitted
+  public static instance: ConnectionManager;
+
+  // Variable: iPAddress
+  // The IP Address that will be used in the <ServiceConnection> to connect to the target
+  // WebSocket. This value is settable in the Inspector.
+  static iPAddress: string = "127.0.0.1";
+
+  // Variable: port
+  // The Port that will be used in the <ServiceConnection> to connect to the target WebSocket.
+  // This value is settable in the Inspector.
+  static port: string = "9739";
+
+  // Variable: currentHandPresence
+  // Private reference to the current hand presense state
+  private static currentHandPresence: HandPresenceState =
+    HandPresenceState.HANDS_LOST;
+
+  // Group: Functions
+
+  // Function: init
+  // Used to begin the connection. Creates the required <MessageReceiver>.
+  // Also attempts to immediately <Connect> to a WebSocket.
+  public static init() {
+    ConnectionManager.messageReceiver = new MessageReceiver();
+    ConnectionManager.instance = new ConnectionManager();
+    ConnectionManager.Connect();
+  }
+
+  // Function: AddConnectionListener
+  // Used to both add the _onConnectFunc action to the listeners of <OnConnected>
+  // as well as auto-call the _onConnectFunc if a connection is already made.
+  public static AddConnectionListener(_onConnectFunc: () => void): void {
+    ConnectionManager.instance.addEventListener(TouchFreeEvent.ON_CONNECTED, _onConnectFunc);
+
+    if (
+      ConnectionManager.currentServiceConnection !== null &&
+      ConnectionManager.currentServiceConnection.webSocket.readyState ===
+        WebSocket.OPEN
+    ) {
+      _onConnectFunc();
+    }
+  }
+
+  // Function: Connect
+  // Creates a new <ServiceConnection> using <iPAddress> and <port>.
+  // Also invokes <OnConnected> on all listeners.
+  public static Connect(): void {
+    ConnectionManager.currentServiceConnection = new ServiceConnection(
+      ConnectionManager.iPAddress,
+      ConnectionManager.port,
+    );
+  }
+
+  // Function: HandleHandPresenceEvent
+  // Called by the <MessageReciever> to pass HandPresence events via the <HandFound> and
+  // <HandsLost> events on this class
+  public static HandleHandPresenceEvent(_state: HandPresenceState): void {
+    ConnectionManager.currentHandPresence = _state;
+
+    let handPresenceEvent: Event;
+
+    if (_state === HandPresenceState.HAND_FOUND) {
+      handPresenceEvent = new Event(TouchFreeEvent.HAND_FOUND);
+    } else {
+      handPresenceEvent = new Event(TouchFreeEvent.HANDS_LOST);
     }
 
-    // Function: Connect
-    // Creates a new <ServiceConnection> using <iPAddress> and <port>.
-    // Also invokes <OnConnected> on all listeners.
-    public static Connect(): void {
-        ConnectionManager.currentServiceConnection = new ServiceConnection(
-            ConnectionManager.iPAddress,
-            ConnectionManager.port);
+    ConnectionManager.instance.dispatchEvent(handPresenceEvent);
+  }
+
+  // Function: Disconnect
+  // Disconnects <currentServiceConnection> if it is connected to a WebSocket and
+  // sets it to null.
+  public static Disconnect(): void {
+    if (ConnectionManager.currentServiceConnection !== null) {
+      ConnectionManager.currentServiceConnection.Disconnect();
+      ConnectionManager.currentServiceConnection = null;
+    }
+  }
+
+  // Function: RequestServiceStatus
+  // Used to request information from the Service via the <ConnectionManager>. Provides an asynchronous
+  // <ServiceStatus> via the _callback parameter.
+  //
+  // If your _callback requires context it should be bound to that context via .bind()
+  public static RequestServiceStatus(
+    _callback: (detail: ServiceStatus) => void,
+  ): void {
+    if (_callback === null) {
+      console.error("Request failed. This is due to a missing callback");
+      return;
     }
 
-    // Function: HandleHandPresenceEvent
-    // Called by the <MessageReciever> to pass HandPresence events via the <HandFound> and
-    // <HandsLost> events on this class
-    public static HandleHandPresenceEvent(_state: HandPresenceState): void {
-        ConnectionManager.currentHandPresence = _state;
-        
-        let handPresenceEvent: CustomEvent;
+    ConnectionManager.serviceConnection()?.RequestServiceStatus(_callback);
+  }
 
-        if (_state === HandPresenceState.HAND_FOUND) {
-            handPresenceEvent = new CustomEvent('HandFound');
-        } else {
-            handPresenceEvent = new CustomEvent('HandsLost');
-        }
-
-        ConnectionManager.instance.dispatchEvent(handPresenceEvent);
-    }
-
-    // Function: Disconnect
-    // Disconnects <currentServiceConnection> if it is connected to a WebSocket and
-    // sets it to null.
-    public static Disconnect(): void {
-        if (ConnectionManager.currentServiceConnection !== null) {
-            ConnectionManager.currentServiceConnection.Disconnect();
-            ConnectionManager.currentServiceConnection = null;
-        }
-    }
-
-    // Function: RequestServiceStatus
-    // Used to request information from the Service via the <ConnectionManager>. Provides an asynchronous
-    // <ServiceStatus> via the _callback parameter.
-    //
-    // If your _callback requires context it should be bound to that context via .bind()
-    public static RequestServiceStatus(_callback: (detail: ServiceStatus) => void): void {
-        if (_callback === null) {
-            console.error("Request failed. This is due to a missing callback");
-            return;
-        }
-
-        ConnectionManager.serviceConnection()?.RequestServiceStatus(_callback);
-    }
-
-    // Function: RequestServiceStatus
-    // Function to get the current hand presense state
-    public static GetCurrentHandPresence(): HandPresenceState {
-        return ConnectionManager.currentHandPresence;
-    }
+  // Function: RequestServiceStatus
+  // Function to get the current hand presense state
+  public static GetCurrentHandPresence(): HandPresenceState {
+    return ConnectionManager.currentHandPresence;
+  }
 }

--- a/TF_Tooling_Web/src/Connection/MessageReceiver.ts
+++ b/TF_Tooling_Web/src/Connection/MessageReceiver.ts
@@ -15,12 +15,16 @@ import {
     BitmaskFlags,
     ConvertInputAction,
     InputType,
+    TouchFreeEvent,
     TouchFreeInputAction,
+    TrackingServiceState,
     WebsocketInputAction,
 } from '../TouchFreeToolingTypes';
 import { InputActionManager } from '../Plugins/InputActionManager';
 import { ConnectionManager } from './ConnectionManager';
 import { HandDataManager } from '../Plugins/HandDataManager';
+
+type CallbackResult = 'Success' | 'CallbacksUndefined' | 'NoCallbacksFound' | Error;
 
 // Class: MessageReceiver
 // Handles the receiving of messages from the Service in an ordered manner.
@@ -170,18 +174,21 @@ export class MessageReceiver {
     // Checks the dictionary of <callbacks> for a matching request ID. If there is a
     // match, calls the callback action in the matching <TouchFreeRequestCallback>.
     // Returns true if it was able to find a callback, returns false if not
-    private static HandleCallbackList<T extends TouchFreeRequest>(callbackResult: T, callbacks: {[id: string]: TouchFreeRequestCallback<T>}) : boolean {
-        if (callbacks !== undefined) {
-            for (let key in callbacks) {
-                if (key === callbackResult.requestID) {
-                    callbacks[key].callback(callbackResult);
-                    delete callbacks[key];
-                    return true;
-                }
-            };
+    private static HandleCallbackList<T extends TouchFreeRequest>(callbackResult: T, callbacks: {[id: string]: TouchFreeRequestCallback<T>}) : CallbackResult {
+        if (callbacks === undefined)
+        {
+            return 'CallbacksUndefined';
         }
+        
+        for (let key in callbacks) {
+            if (key === callbackResult.requestID) {
+                callbacks[key].callback(callbackResult);
+                delete callbacks[key];
+                return 'Success';
+            }
+        };
 
-        return false;
+        return 'NoCallbacksFound';
     }
 
     // Function: CheckForServiceStatus
@@ -191,7 +198,15 @@ export class MessageReceiver {
         let serviceStatus: ServiceStatus | undefined = this.serviceStatusQueue.shift();
 
         if (serviceStatus !== undefined) {
-            MessageReceiver.HandleCallbackList(serviceStatus, this.serviceStatusCallbacks);
+            const callbackResult = MessageReceiver.HandleCallbackList(serviceStatus, this.serviceStatusCallbacks);
+
+            // If callback didn't happen for known reasons, we cna be sure it's an independent status event rather than a request response
+            if (callbackResult === 'NoCallbacksFound' || callbackResult === 'CallbacksUndefined')
+            {
+                ConnectionManager.instance.dispatchEvent(
+                    new CustomEvent<TrackingServiceState>(TouchFreeEvent.ON_TRACKING_SERVICE_STATE_CHANGE,
+                        {detail: serviceStatus.trackingServiceState ?? undefined}));
+            }
         }
     }
 

--- a/TF_Tooling_Web/src/Connection/ServiceConnection.ts
+++ b/TF_Tooling_Web/src/Connection/ServiceConnection.ts
@@ -1,4 +1,5 @@
 import {
+    TouchFreeEvent,
     VersionInfo,
     WebsocketInputAction
 } from '../TouchFreeToolingTypes';
@@ -96,7 +97,7 @@ export class ServiceConnection {
             console.log("Successful Connection");
 
             this.handshakeCompleted = true;
-            ConnectionManager.instance.dispatchEvent(new Event('OnConnected'));
+            ConnectionManager.instance.dispatchEvent(new Event(TouchFreeEvent.ON_CONNECTED));
         }
         else {
             console.log(`Connection to Service failed. Details:\n${response.message}`);

--- a/TF_Tooling_Web/src/Cursors/DotCursor.ts
+++ b/TF_Tooling_Web/src/Cursors/DotCursor.ts
@@ -1,7 +1,8 @@
 import { TouchlessCursor } from './TouchlessCursor';
 import {
     TouchFreeInputAction,
-    InputType
+    InputType,
+    TouchFreeEvent
 } from '../TouchFreeToolingTypes';
 import { ConnectionManager } from '../Connection/ConnectionManager';
 import { MapRangeToRange } from '../Utilities';
@@ -59,8 +60,8 @@ export class DotCursor extends TouchlessCursor {
         this.animationSpeed[0] = (this.cursorStartSize[0] / 2) / (_animationDuration * 30);
         this.animationSpeed[1] = (this.cursorStartSize[1] / 2) / (_animationDuration * 30);
 
-        ConnectionManager.instance.addEventListener('HandFound', this.ShowCursor.bind(this));
-        ConnectionManager.instance.addEventListener('HandsLost', this.HideCursor.bind(this));
+        ConnectionManager.instance.addEventListener(TouchFreeEvent.HAND_FOUND, this.ShowCursor.bind(this));
+        ConnectionManager.instance.addEventListener(TouchFreeEvent.HANDS_LOST, this.HideCursor.bind(this));
     }
 
     // Function: UpdateCursor

--- a/TF_Tooling_Web/src/Cursors/TouchlessCursor.ts
+++ b/TF_Tooling_Web/src/Cursors/TouchlessCursor.ts
@@ -1,4 +1,4 @@
-import { TouchFreeInputAction } from '../TouchFreeToolingTypes';
+import { TouchFreeEvent, TouchFreeInputAction } from '../TouchFreeToolingTypes';
 import { InputActionManager } from '../Plugins/InputActionManager';
 
 
@@ -31,7 +31,7 @@ export abstract class TouchlessCursor {
     // If you intend to make use of the <WebInputController>, make sure that _cursor has the
     // "touchfree-cursor" class. This prevents it blocking other elements from recieving events.
     constructor(_cursor: HTMLElement | SVGElement | undefined) {
-        InputActionManager.instance.addEventListener('TransmitInputAction', ((e: CustomEvent<TouchFreeInputAction>) => {
+        InputActionManager.instance.addEventListener(TouchFreeEvent.TRAMSIT_INPUT_ACTION, ((e: CustomEvent<TouchFreeInputAction>) => {
             this.HandleInputAction(e.detail);
         }) as EventListener);
 

--- a/TF_Tooling_Web/src/InputControllers/BaseInputController.ts
+++ b/TF_Tooling_Web/src/InputControllers/BaseInputController.ts
@@ -1,5 +1,5 @@
 import { InputActionManager } from '../Plugins/InputActionManager';
-import { TouchFreeInputAction, InputType } from "../TouchFreeToolingTypes";
+import { TouchFreeInputAction, InputType, TouchFreeEvent } from "../TouchFreeToolingTypes";
 
 // Class: InputController
 // InputControllers convert <TouchFreeInputActions> as recieved from the service into appropriate
@@ -20,7 +20,7 @@ export abstract class BaseInputController {
     constructor() {
         if (!BaseInputController.Instantiated) {
             BaseInputController.Instantiated = true;
-            InputActionManager.instance.addEventListener('TransmitInputAction',
+            InputActionManager.instance.addEventListener(TouchFreeEvent.TRAMSIT_INPUT_ACTION,
                 ((e: CustomEvent<TouchFreeInputAction>) => {
                     this.HandleInputAction(e.detail);
                 }) as EventListener);
@@ -55,7 +55,7 @@ export abstract class BaseInputController {
     }
 
     disconnect() {
-        InputActionManager.instance.removeEventListener('TransmitInputAction',
+        InputActionManager.instance.removeEventListener(TouchFreeEvent.TRAMSIT_INPUT_ACTION,
             ((e: CustomEvent<TouchFreeInputAction>) => {
                 this.HandleInputAction(e.detail);
             }) as EventListener);

--- a/TF_Tooling_Web/src/InputControllers/WebInputController.ts
+++ b/TF_Tooling_Web/src/InputControllers/WebInputController.ts
@@ -1,6 +1,7 @@
 import {
     TouchFreeInputAction,
-    InputType
+    InputType,
+    TouchFreeEvent
 } from '../TouchFreeToolingTypes';
 import { BaseInputController } from './BaseInputController'
 
@@ -112,7 +113,7 @@ export class WebInputController extends BaseInputController {
         this.activeEventProps.clientY = _inputData.CursorPosition[1];
 
         if (elementAtPos !== null) {
-            let inputEvent: CustomEvent = new CustomEvent(`InputAction`, {detail: _inputData})
+            const inputEvent = new CustomEvent<TouchFreeInputAction>(TouchFreeEvent.INPUT_ACTION, {detail: _inputData})
             elementAtPos.dispatchEvent(inputEvent);
         }
 

--- a/TF_Tooling_Web/src/Plugins/InputActionManager.ts
+++ b/TF_Tooling_Web/src/Plugins/InputActionManager.ts
@@ -1,4 +1,4 @@
-import { TouchFreeInputAction } from "../TouchFreeToolingTypes";
+import { TouchFreeEvent, TouchFreeInputAction } from "../TouchFreeToolingTypes";
 import { InputActionPlugin } from "./InputActionPlugin";
 
 // Class: InputActionManager
@@ -42,7 +42,7 @@ export class InputActionManager extends EventTarget {
     public static HandleInputAction(_action: TouchFreeInputAction): void {
 
         let rawInputActionEvent: CustomEvent<TouchFreeInputAction> = new CustomEvent<TouchFreeInputAction>(
-            'TransmitInputActionRaw',
+            TouchFreeEvent.TRAMSIT_INPUT_ACTION_RAW,
             { detail: _action }
         );
         InputActionManager.instance.dispatchEvent(rawInputActionEvent);
@@ -63,7 +63,7 @@ export class InputActionManager extends EventTarget {
         }
 
         let inputActionEvent: CustomEvent<TouchFreeInputAction> = new CustomEvent<TouchFreeInputAction>(
-            'TransmitInputAction',
+            TouchFreeEvent.TRAMSIT_INPUT_ACTION,
             { detail: action }
         );
 

--- a/TF_Tooling_Web/src/Plugins/InputActionPlugin.ts
+++ b/TF_Tooling_Web/src/Plugins/InputActionPlugin.ts
@@ -1,4 +1,4 @@
-import { TouchFreeInputAction } from "../TouchFreeToolingTypes";
+import { TouchFreeEvent, TouchFreeInputAction } from "../TouchFreeToolingTypes";
 
 export abstract class InputActionPlugin extends EventTarget{
     // Event: InputActionOutput
@@ -32,7 +32,7 @@ export abstract class InputActionPlugin extends EventTarget{
     // To be used to Invoke the InputActionOutput event from any child class of this base.
     TransmitInputAction(_inputAction: TouchFreeInputAction): void{
         let InputActionEvent: CustomEvent<TouchFreeInputAction> = new CustomEvent<TouchFreeInputAction>(
-            'InputActionOutput',
+            TouchFreeEvent.INPUT_ACTION_OUTPUT,
             { detail: _inputAction }
         );
         this.dispatchEvent(InputActionEvent);

--- a/TF_Tooling_Web/src/TouchFreeToolingTypes.ts
+++ b/TF_Tooling_Web/src/TouchFreeToolingTypes.ts
@@ -2,86 +2,88 @@ import { Vector } from "./Configuration/ConfigurationTypes";
 
 // Class: VersionInfo
 // This class is used when comparing the <ApiVersion> of the Tooling and the Service.
-export class VersionInfo
-{
-    // Group: Variables
+export class VersionInfo {
+  // Group: Variables
 
-    // Variable: ApiVersion
-    // The current API version of the Tooling.
-    public static readonly ApiVersion: string = "1.3.0";
+  // Variable: ApiVersion
+  // The current API version of the Tooling.
+  public static readonly ApiVersion: string = "1.3.0";
 
-    // Variable: API_HEADER_NAME
-    // The name of the header we wish the Service to compare our version with.
-    public static readonly API_HEADER_NAME: string = "TfApiVersion";
+  // Variable: API_HEADER_NAME
+  // The name of the header we wish the Service to compare our version with.
+  public static readonly API_HEADER_NAME: string = "TfApiVersion";
 }
 
 // Class: TouchFreeInputAction
 // A structure representing the Tooling verison of an InputAction. This is used to pass
 // key information relating to an action that has happened on the Service.
 export class TouchFreeInputAction {
-    Timestamp: number;
-    InteractionType: InteractionType;
-    HandType: HandType;
-    Chirality: HandChirality;
-    InputType: InputType;
-    CursorPosition: Array<number>;
-    DistanceFromScreen: number;
-    ProgressToClick: number;
+  Timestamp: number;
+  InteractionType: InteractionType;
+  HandType: HandType;
+  Chirality: HandChirality;
+  InputType: InputType;
+  CursorPosition: Array<number>;
+  DistanceFromScreen: number;
+  ProgressToClick: number;
 
-    constructor(
-        _timestamp: number,
-        _interactionType: InteractionType,
-        _handType: HandType,
-        _handChirality: HandChirality,
-        _inputType: InputType,
-        _cursorPosition: Array<number>,
-        _distanceFromScreen: number,
-        _progressToClick: number)
-    {
-        this.Timestamp = _timestamp;
-        this.InteractionType = _interactionType;
-        this.HandType = _handType;
-        this.Chirality = _handChirality;
-        this.InputType = _inputType;
-        this.CursorPosition = _cursorPosition;
-        this.DistanceFromScreen = _distanceFromScreen;
-        this.ProgressToClick = _progressToClick;
-    }
+  constructor(
+    _timestamp: number,
+    _interactionType: InteractionType,
+    _handType: HandType,
+    _handChirality: HandChirality,
+    _inputType: InputType,
+    _cursorPosition: Array<number>,
+    _distanceFromScreen: number,
+    _progressToClick: number,
+  ) {
+    this.Timestamp = _timestamp;
+    this.InteractionType = _interactionType;
+    this.HandType = _handType;
+    this.Chirality = _handChirality;
+    this.InputType = _inputType;
+    this.CursorPosition = _cursorPosition;
+    this.DistanceFromScreen = _distanceFromScreen;
+    this.ProgressToClick = _progressToClick;
+  }
 }
 
 // Function: ConvertInputAction
 // Used to translate the raw actions that come across the websocket (<WebsocketInputActions>) and
 // convert them into the Tooling-friendly <TouchFreeInputAction> format.
-export function ConvertInputAction(_wsInput: WebsocketInputAction): TouchFreeInputAction {
-    const yPosition = window.innerHeight - (_wsInput.CursorPosition.y / window.devicePixelRatio);
-    const xPosition = _wsInput.CursorPosition.x / window.devicePixelRatio;
+export function ConvertInputAction(
+  _wsInput: WebsocketInputAction,
+): TouchFreeInputAction {
+  const yPosition = window.innerHeight -
+    (_wsInput.CursorPosition.y / window.devicePixelRatio);
+  const xPosition = _wsInput.CursorPosition.x / window.devicePixelRatio;
 
-    return new TouchFreeInputAction(
-        _wsInput.Timestamp,
-        FlagUtilities.GetInteractionTypeFromFlags(_wsInput.InteractionFlags),
-        FlagUtilities.GetHandTypeFromFlags(_wsInput.InteractionFlags),
-        FlagUtilities.GetChiralityFromFlags(_wsInput.InteractionFlags),
-        FlagUtilities.GetInputTypeFromFlags(_wsInput.InteractionFlags),
-        [xPosition, yPosition],
-        _wsInput.DistanceFromScreen,
-        _wsInput.ProgressToClick,
-    );
+  return new TouchFreeInputAction(
+    _wsInput.Timestamp,
+    FlagUtilities.GetInteractionTypeFromFlags(_wsInput.InteractionFlags),
+    FlagUtilities.GetHandTypeFromFlags(_wsInput.InteractionFlags),
+    FlagUtilities.GetChiralityFromFlags(_wsInput.InteractionFlags),
+    FlagUtilities.GetInputTypeFromFlags(_wsInput.InteractionFlags),
+    [xPosition, yPosition],
+    _wsInput.DistanceFromScreen,
+    _wsInput.ProgressToClick,
+  );
 }
 
 // Enum: HandChirality
 // LEFT - The left hand
 // RIGHT - The right hand
 export enum HandChirality {
-    LEFT,
-    RIGHT
+  LEFT,
+  RIGHT,
 }
 
 // Enum: HandType
 // PRIMARY - The first hand found
 // SECONDARY - The second hand found
 export enum HandType {
-    PRIMARY,
-    SECONDARY,
+  PRIMARY,
+  SECONDARY,
 }
 
 // Enum: InputType
@@ -91,11 +93,11 @@ export enum HandType {
 // MOVE - Used to move a cursor or to perform a 'Drag' after a DOWN
 // UP - Used to complete a 'Touch' or a 'Drag'
 export enum InputType {
-    NONE,
-    CANCEL,
-    DOWN,
-    MOVE,
-    UP,
+  NONE,
+  CANCEL,
+  DOWN,
+  MOVE,
+  UP,
 }
 
 // Enum: InteractionType
@@ -103,11 +105,11 @@ export enum InputType {
 // HOVER - The user must perform a HOVER gesture to 'Touch' by holding their hand still for a fixed time
 // PUSH - The user must perform a PUSH gesture to 'Touch' by pushing their hand toward the screen
 export enum InteractionType {
-    GRAB,
-    HOVER,
-    PUSH,
-    TOUCHPLANE,
-    VELOCITYSWIPE,
+  GRAB,
+  HOVER,
+  PUSH,
+  TOUCHPLANE,
+  VELOCITYSWIPE,
 }
 
 // Enum: TrackingServiceState
@@ -115,9 +117,9 @@ export enum InteractionType {
 // NO_CAMERA - The TouchFree service is connected to the tracking service but there is not a camera connected
 // CONNECTED - The TouchFree service is connected to the tracking service
 export enum TrackingServiceState {
-    UNAVAILABLE,
-    NO_CAMERA,
-    CONNECTED,
+  UNAVAILABLE,
+  NO_CAMERA,
+  CONNECTED,
 }
 
 // Enum: ConfigurationState
@@ -125,71 +127,93 @@ export enum TrackingServiceState {
 // LOADED - The TouchFree configuration has successfully been loaded
 // ERRORED - The TouchFree configuration errored on load
 export enum ConfigurationState {
-    NOT_LOADED,
-    LOADED,
-    ERRORED
+  NOT_LOADED,
+  LOADED,
+  ERRORED,
 }
 
 // Enum: BitmaskFlags
 // This is used to request any combination of the <HandChiralities>, <HandTypes>, <InputTypes>,
 // and <InteractionTypes> flags from the Service at once.
 export enum BitmaskFlags {
-    NONE = 0,
+  NONE = 0,
 
-    // HandChirality
-    LEFT = 1,
-    RIGHT = 2,
+  // HandChirality
+  LEFT = 1,
+  RIGHT = 2,
 
-    // Hand Type
-    PRIMARY = 4,
-    SECONDARY = 8,
+  // Hand Type
+  PRIMARY = 4,
+  SECONDARY = 8,
 
-    // Input Types
-    NONE_INPUT = 16,
-    CANCEL = 32,
-    DOWN = 64,
-    MOVE = 128,
-    UP = 256,
+  // Input Types
+  NONE_INPUT = 16,
+  CANCEL = 32,
+  DOWN = 64,
+  MOVE = 128,
+  UP = 256,
 
-    // Interaction Types
-    GRAB = 512,
-    HOVER = 1024,
-    PUSH = 2048,
-    TOUCHPLANE = 4096,
-    VELOCITYSWIPE = 8192,
+  // Interaction Types
+  GRAB = 512,
+  HOVER = 1024,
+  PUSH = 2048,
+  TOUCHPLANE = 4096,
+  VELOCITYSWIPE = 8192,
+  // Adding elements to this list is a breaking change, and should cause at
+  // least a minor iteration of the API version UNLESS adding them at the end
+}
 
-    // Adding elements to this list is a breaking change, and should cause at
-    // least a minor iteration of the API version UNLESS adding them at the end
+// Enum: TouchFreeEvent
+// ON_CONNECTED - Event dispatched when connecting to the TouchFree service
+// ON_TRACKING_SERVICE_STATE_CHANGE - Event dispatched when the connection between TouchFreeService and Ultraleap Tracking Service changes
+// HANDS_FOUND - Event dispatched when the first hand has started tracking
+// HANDS_LOST - Event dispatched when the last hand has stopped tracking
+// INPUT_ACTION - Event dispatched when any input action is received from the TouchFree service
+// INPUT_ACTION_OUTPUT - ??? (Never subscribed to?)
+// TRANSMIT_INPUT_ACTION_RAW - Event dispatched directly from the <InputActionManager> without any proxying
+// TRANSMIT_INPUT_ACTION - Event dispatched from the <InputActionManager> to each registered Plugin
+export enum TouchFreeEvent {
+  ON_CONNECTED = "OnConnected",
+  ON_TRACKING_SERVICE_STATE_CHANGE = "OnTrackingServiceStateChange",
+
+  HAND_FOUND = "HandFound",
+  HANDS_LOST = "HandsLost",
+
+  INPUT_ACTION = "InputAction",
+  INPUT_ACTION_OUTPUT = "InputActionOutput",
+
+  TRAMSIT_INPUT_ACTION_RAW = "TransmitInputActionRaw",
+  TRAMSIT_INPUT_ACTION = "TransmitInputAction",
 }
 
 // Class: WebsocketInputAction
 // The version of an InputAction received via the WebSocket. This must be converted into a
 // <TouchFreeInputAction> to be used by the Tooling and can be done so via ConvertInputAction.
 export class WebsocketInputAction {
-    // Variable: Timestamp
-    Timestamp: number;
-    // Variable: InteractionFlags
-    InteractionFlags: BitmaskFlags;
-    // Variable: CursorPosition
-    CursorPosition: any;
-    // Variable: DistanceFromScreen
-    DistanceFromScreen: number;
-    // Variable: ProgressToClick
-    ProgressToClick: number;
+  // Variable: Timestamp
+  Timestamp: number;
+  // Variable: InteractionFlags
+  InteractionFlags: BitmaskFlags;
+  // Variable: CursorPosition
+  CursorPosition: any;
+  // Variable: DistanceFromScreen
+  DistanceFromScreen: number;
+  // Variable: ProgressToClick
+  ProgressToClick: number;
 
-    constructor(
-        _timestamp: number,
-        _interactionFlags: BitmaskFlags,
-        _cursorPosition: any,
-        _distanceFromScreen: number,
-        _progressToClick: number,
-    ) {
-        this.Timestamp = _timestamp;
-        this.InteractionFlags = _interactionFlags;
-        this.CursorPosition = _cursorPosition;
-        this.DistanceFromScreen = _distanceFromScreen;
-        this.ProgressToClick = _progressToClick;
-    }
+  constructor(
+    _timestamp: number,
+    _interactionFlags: BitmaskFlags,
+    _cursorPosition: any,
+    _distanceFromScreen: number,
+    _progressToClick: number,
+  ) {
+    this.Timestamp = _timestamp;
+    this.InteractionFlags = _interactionFlags;
+    this.CursorPosition = _cursorPosition;
+    this.DistanceFromScreen = _distanceFromScreen;
+    this.ProgressToClick = _progressToClick;
+  }
 }
 
 // Class: HandFrame
@@ -240,172 +264,167 @@ export class RawBone
 // Class: FlagUtilities
 // A collection of Utilities to be used when working with <BitmaskFlags>.
 export class FlagUtilities {
-    // Group: Functions
+  // Group: Functions
 
-    // Function: GetInteractionFlags
-    // Used to convert a collection of interaction enums to flags for sending
-    // to the Service.
-    static GetInteractionFlags(
-        _interactionType: InteractionType,
-        _handType: HandType,
-        _chirality: HandChirality,
-        _inputType: InputType): BitmaskFlags {
-        let returnVal: BitmaskFlags = BitmaskFlags.NONE;
+  // Function: GetInteractionFlags
+  // Used to convert a collection of interaction enums to flags for sending
+  // to the Service.
+  static GetInteractionFlags(
+    _interactionType: InteractionType,
+    _handType: HandType,
+    _chirality: HandChirality,
+    _inputType: InputType,
+  ): BitmaskFlags {
+    let returnVal: BitmaskFlags = BitmaskFlags.NONE;
 
-        switch (_handType) {
-            case HandType.PRIMARY:
-                returnVal ^= BitmaskFlags.PRIMARY;
-                break;
+    switch (_handType) {
+      case HandType.PRIMARY:
+        returnVal ^= BitmaskFlags.PRIMARY;
+        break;
 
-            case HandType.SECONDARY:
-                returnVal ^= BitmaskFlags.SECONDARY;
-                break;
-        }
-
-        switch (_chirality) {
-            case HandChirality.LEFT:
-                returnVal ^= BitmaskFlags.LEFT;
-                break;
-
-            case HandChirality.RIGHT:
-                returnVal ^= BitmaskFlags.RIGHT;
-                break;
-        }
-
-        switch (_inputType) {
-            case InputType.NONE:
-                returnVal ^= BitmaskFlags.NONE_INPUT;
-                break;
-
-            case InputType.CANCEL:
-                returnVal ^= BitmaskFlags.CANCEL;
-                break;
-
-            case InputType.MOVE:
-                returnVal ^= BitmaskFlags.MOVE;
-                break;
-
-            case InputType.UP:
-                returnVal ^= BitmaskFlags.UP;
-                break;
-
-            case InputType.DOWN:
-                returnVal ^= BitmaskFlags.DOWN;
-                break;
-        }
-
-        switch (_interactionType) {
-            case InteractionType.PUSH:
-                returnVal ^= BitmaskFlags.PUSH;
-                break;
-
-            case InteractionType.HOVER:
-                returnVal ^= BitmaskFlags.HOVER;
-                break;
-
-            case InteractionType.GRAB:
-                returnVal ^= BitmaskFlags.GRAB;
-                break;
-
-            case InteractionType.TOUCHPLANE:
-                returnVal ^= BitmaskFlags.TOUCHPLANE;
-                break;
-
-            case InteractionType.VELOCITYSWIPE:
-                returnVal ^= BitmaskFlags.VELOCITYSWIPE;
-                break;
-        }
-
-        return returnVal;
+      case HandType.SECONDARY:
+        returnVal ^= BitmaskFlags.SECONDARY;
+        break;
     }
 
-    // Function: GetChiralityFromFlags
-    // Used to find which <HandChirality> _flags contains. Favours RIGHT if none or both are found.
-    static GetChiralityFromFlags(_flags: BitmaskFlags): HandChirality {
-        let chirality: HandChirality = HandChirality.RIGHT;
+    switch (_chirality) {
+      case HandChirality.LEFT:
+        returnVal ^= BitmaskFlags.LEFT;
+        break;
 
-        if (_flags & BitmaskFlags.RIGHT) {
-            chirality = HandChirality.RIGHT;
-        }
-        else if (_flags & BitmaskFlags.LEFT) {
-            chirality = HandChirality.LEFT;
-        }
-        else {
-            console.error("InputActionData missing: No Chirality found. Defaulting to 'RIGHT'");
-        }
-
-        return chirality;
+      case HandChirality.RIGHT:
+        returnVal ^= BitmaskFlags.RIGHT;
+        break;
     }
 
-    // Function: GetHandTypeFromFlags
-    // Used to find which <HandType> _flags contains. Favours PRIMARY if none or both are found.
-    static GetHandTypeFromFlags(_flags: BitmaskFlags): HandType {
-        let handType: HandType = HandType.PRIMARY;
+    switch (_inputType) {
+      case InputType.NONE:
+        returnVal ^= BitmaskFlags.NONE_INPUT;
+        break;
 
-        if (_flags & BitmaskFlags.PRIMARY) {
-            handType = HandType.PRIMARY;
-        }
-        else if (_flags & BitmaskFlags.SECONDARY) {
-            handType = HandType.SECONDARY;
-        }
-        else {
-            console.error("InputActionData missing: No HandData found. Defaulting to 'PRIMARY'");
-        }
+      case InputType.CANCEL:
+        returnVal ^= BitmaskFlags.CANCEL;
+        break;
 
-        return handType;
+      case InputType.MOVE:
+        returnVal ^= BitmaskFlags.MOVE;
+        break;
+
+      case InputType.UP:
+        returnVal ^= BitmaskFlags.UP;
+        break;
+
+      case InputType.DOWN:
+        returnVal ^= BitmaskFlags.DOWN;
+        break;
     }
 
-    // Function: GetInputTypeFromFlags
-    // Used to find which <InputType> _flags contains. Favours NONE if none are found.
-    static GetInputTypeFromFlags(_flags: BitmaskFlags): InputType {
-        let inputType: InputType = InputType.NONE;
+    switch (_interactionType) {
+      case InteractionType.PUSH:
+        returnVal ^= BitmaskFlags.PUSH;
+        break;
 
-        if (_flags & BitmaskFlags.NONE_INPUT) {
-            inputType = InputType.NONE;
-        }
-        else if (_flags & BitmaskFlags.CANCEL) {
-            inputType = InputType.CANCEL;
-        }
-        else if (_flags & BitmaskFlags.UP) {
-            inputType = InputType.UP;
-        }
-        else if (_flags & BitmaskFlags.DOWN) {
-            inputType = InputType.DOWN;
-        }
-        else if (_flags & BitmaskFlags.MOVE) {
-            inputType = InputType.MOVE;
-        }
-        else {
-            console.error("InputActionData missing: No InputType found. Defaulting to 'NONE'");
-        }
+      case InteractionType.HOVER:
+        returnVal ^= BitmaskFlags.HOVER;
+        break;
 
-        return inputType;
+      case InteractionType.GRAB:
+        returnVal ^= BitmaskFlags.GRAB;
+        break;
+
+      case InteractionType.TOUCHPLANE:
+        returnVal ^= BitmaskFlags.TOUCHPLANE;
+        break;
+
+      case InteractionType.VELOCITYSWIPE:
+        returnVal ^= BitmaskFlags.VELOCITYSWIPE;
+        break;
     }
 
-    // Function: GetInteractionTypeFromFlags
-    // Used to find which <InteractionType> _flags contains. Favours PUSH if none are found.
-    static GetInteractionTypeFromFlags(_flags: BitmaskFlags): InteractionType {
-        let interactionType: InteractionType = InteractionType.PUSH;
+    return returnVal;
+  }
 
-        if (_flags & BitmaskFlags.PUSH) {
-            interactionType = InteractionType.PUSH;
-        }
-        else if (_flags & BitmaskFlags.HOVER) {
-            interactionType = InteractionType.HOVER;
-        }
-        else if (_flags & BitmaskFlags.GRAB) {
-            interactionType = InteractionType.GRAB;
-        }
-        else if (_flags & BitmaskFlags.TOUCHPLANE) {
-            interactionType = InteractionType.TOUCHPLANE;
-        }
-        else if (_flags & BitmaskFlags.VELOCITYSWIPE) {
-            interactionType = InteractionType.VELOCITYSWIPE;
-        }
-        else {
-            console.error("InputActionData missing: No InteractionType found. Defaulting to 'PUSH'");
-        }
+  // Function: GetChiralityFromFlags
+  // Used to find which <HandChirality> _flags contains. Favours RIGHT if none or both are found.
+  static GetChiralityFromFlags(_flags: BitmaskFlags): HandChirality {
+    let chirality: HandChirality = HandChirality.RIGHT;
 
-        return interactionType;
+    if (_flags & BitmaskFlags.RIGHT) {
+      chirality = HandChirality.RIGHT;
+    } else if (_flags & BitmaskFlags.LEFT) {
+      chirality = HandChirality.LEFT;
+    } else {
+      console.error(
+        "InputActionData missing: No Chirality found. Defaulting to 'RIGHT'",
+      );
     }
+
+    return chirality;
+  }
+
+  // Function: GetHandTypeFromFlags
+  // Used to find which <HandType> _flags contains. Favours PRIMARY if none or both are found.
+  static GetHandTypeFromFlags(_flags: BitmaskFlags): HandType {
+    let handType: HandType = HandType.PRIMARY;
+
+    if (_flags & BitmaskFlags.PRIMARY) {
+      handType = HandType.PRIMARY;
+    } else if (_flags & BitmaskFlags.SECONDARY) {
+      handType = HandType.SECONDARY;
+    } else {
+      console.error(
+        "InputActionData missing: No HandData found. Defaulting to 'PRIMARY'",
+      );
+    }
+
+    return handType;
+  }
+
+  // Function: GetInputTypeFromFlags
+  // Used to find which <InputType> _flags contains. Favours NONE if none are found.
+  static GetInputTypeFromFlags(_flags: BitmaskFlags): InputType {
+    let inputType: InputType = InputType.NONE;
+
+    if (_flags & BitmaskFlags.NONE_INPUT) {
+      inputType = InputType.NONE;
+    } else if (_flags & BitmaskFlags.CANCEL) {
+      inputType = InputType.CANCEL;
+    } else if (_flags & BitmaskFlags.UP) {
+      inputType = InputType.UP;
+    } else if (_flags & BitmaskFlags.DOWN) {
+      inputType = InputType.DOWN;
+    } else if (_flags & BitmaskFlags.MOVE) {
+      inputType = InputType.MOVE;
+    } else {
+      console.error(
+        "InputActionData missing: No InputType found. Defaulting to 'NONE'",
+      );
+    }
+
+    return inputType;
+  }
+
+  // Function: GetInteractionTypeFromFlags
+  // Used to find which <InteractionType> _flags contains. Favours PUSH if none are found.
+  static GetInteractionTypeFromFlags(_flags: BitmaskFlags): InteractionType {
+    let interactionType: InteractionType = InteractionType.PUSH;
+
+    if (_flags & BitmaskFlags.PUSH) {
+      interactionType = InteractionType.PUSH;
+    } else if (_flags & BitmaskFlags.HOVER) {
+      interactionType = InteractionType.HOVER;
+    } else if (_flags & BitmaskFlags.GRAB) {
+      interactionType = InteractionType.GRAB;
+    } else if (_flags & BitmaskFlags.TOUCHPLANE) {
+      interactionType = InteractionType.TOUCHPLANE;
+    } else if (_flags & BitmaskFlags.VELOCITYSWIPE) {
+      interactionType = InteractionType.VELOCITYSWIPE;
+    } else {
+      console.error(
+        "InputActionData missing: No InteractionType found. Defaulting to 'PUSH'",
+      );
+    }
+
+    return interactionType;
+  }
 }

--- a/TF_Tooling_Web/src/TouchFreeToolingTypes.ts
+++ b/TF_Tooling_Web/src/TouchFreeToolingTypes.ts
@@ -3,87 +3,87 @@ import { Vector } from "./Configuration/ConfigurationTypes";
 // Class: VersionInfo
 // This class is used when comparing the <ApiVersion> of the Tooling and the Service.
 export class VersionInfo {
-  // Group: Variables
+    // Group: Variables
 
-  // Variable: ApiVersion
-  // The current API version of the Tooling.
-  public static readonly ApiVersion: string = "1.3.0";
+    // Variable: ApiVersion
+    // The current API version of the Tooling.
+    public static readonly ApiVersion: string = "1.3.0";
 
-  // Variable: API_HEADER_NAME
-  // The name of the header we wish the Service to compare our version with.
-  public static readonly API_HEADER_NAME: string = "TfApiVersion";
+    // Variable: API_HEADER_NAME
+    // The name of the header we wish the Service to compare our version with.
+    public static readonly API_HEADER_NAME: string = "TfApiVersion";
 }
 
 // Class: TouchFreeInputAction
 // A structure representing the Tooling verison of an InputAction. This is used to pass
 // key information relating to an action that has happened on the Service.
 export class TouchFreeInputAction {
-  Timestamp: number;
-  InteractionType: InteractionType;
-  HandType: HandType;
-  Chirality: HandChirality;
-  InputType: InputType;
-  CursorPosition: Array<number>;
-  DistanceFromScreen: number;
-  ProgressToClick: number;
+    Timestamp: number;
+    InteractionType: InteractionType;
+    HandType: HandType;
+    Chirality: HandChirality;
+    InputType: InputType;
+    CursorPosition: Array<number>;
+    DistanceFromScreen: number;
+    ProgressToClick: number;
 
-  constructor(
-    _timestamp: number,
-    _interactionType: InteractionType,
-    _handType: HandType,
-    _handChirality: HandChirality,
-    _inputType: InputType,
-    _cursorPosition: Array<number>,
-    _distanceFromScreen: number,
-    _progressToClick: number,
-  ) {
-    this.Timestamp = _timestamp;
-    this.InteractionType = _interactionType;
-    this.HandType = _handType;
-    this.Chirality = _handChirality;
-    this.InputType = _inputType;
-    this.CursorPosition = _cursorPosition;
-    this.DistanceFromScreen = _distanceFromScreen;
-    this.ProgressToClick = _progressToClick;
-  }
+    constructor(
+        _timestamp: number,
+        _interactionType: InteractionType,
+        _handType: HandType,
+        _handChirality: HandChirality,
+        _inputType: InputType,
+        _cursorPosition: Array<number>,
+        _distanceFromScreen: number,
+        _progressToClick: number,
+    ) {
+        this.Timestamp = _timestamp;
+        this.InteractionType = _interactionType;
+        this.HandType = _handType;
+        this.Chirality = _handChirality;
+        this.InputType = _inputType;
+        this.CursorPosition = _cursorPosition;
+        this.DistanceFromScreen = _distanceFromScreen;
+        this.ProgressToClick = _progressToClick;
+    }
 }
 
 // Function: ConvertInputAction
 // Used to translate the raw actions that come across the websocket (<WebsocketInputActions>) and
 // convert them into the Tooling-friendly <TouchFreeInputAction> format.
 export function ConvertInputAction(
-  _wsInput: WebsocketInputAction,
+    _wsInput: WebsocketInputAction,
 ): TouchFreeInputAction {
-  const yPosition = window.innerHeight -
-    (_wsInput.CursorPosition.y / window.devicePixelRatio);
-  const xPosition = _wsInput.CursorPosition.x / window.devicePixelRatio;
+    const yPosition = window.innerHeight -
+        (_wsInput.CursorPosition.y / window.devicePixelRatio);
+    const xPosition = _wsInput.CursorPosition.x / window.devicePixelRatio;
 
-  return new TouchFreeInputAction(
-    _wsInput.Timestamp,
-    FlagUtilities.GetInteractionTypeFromFlags(_wsInput.InteractionFlags),
-    FlagUtilities.GetHandTypeFromFlags(_wsInput.InteractionFlags),
-    FlagUtilities.GetChiralityFromFlags(_wsInput.InteractionFlags),
-    FlagUtilities.GetInputTypeFromFlags(_wsInput.InteractionFlags),
-    [xPosition, yPosition],
-    _wsInput.DistanceFromScreen,
-    _wsInput.ProgressToClick,
-  );
+    return new TouchFreeInputAction(
+        _wsInput.Timestamp,
+        FlagUtilities.GetInteractionTypeFromFlags(_wsInput.InteractionFlags),
+        FlagUtilities.GetHandTypeFromFlags(_wsInput.InteractionFlags),
+        FlagUtilities.GetChiralityFromFlags(_wsInput.InteractionFlags),
+        FlagUtilities.GetInputTypeFromFlags(_wsInput.InteractionFlags),
+        [xPosition, yPosition],
+        _wsInput.DistanceFromScreen,
+        _wsInput.ProgressToClick,
+    );
 }
 
 // Enum: HandChirality
 // LEFT - The left hand
 // RIGHT - The right hand
 export enum HandChirality {
-  LEFT,
-  RIGHT,
+    LEFT,
+    RIGHT,
 }
 
 // Enum: HandType
 // PRIMARY - The first hand found
 // SECONDARY - The second hand found
 export enum HandType {
-  PRIMARY,
-  SECONDARY,
+    PRIMARY,
+    SECONDARY,
 }
 
 // Enum: InputType
@@ -93,11 +93,11 @@ export enum HandType {
 // MOVE - Used to move a cursor or to perform a 'Drag' after a DOWN
 // UP - Used to complete a 'Touch' or a 'Drag'
 export enum InputType {
-  NONE,
-  CANCEL,
-  DOWN,
-  MOVE,
-  UP,
+    NONE,
+    CANCEL,
+    DOWN,
+    MOVE,
+    UP,
 }
 
 // Enum: InteractionType
@@ -105,11 +105,11 @@ export enum InputType {
 // HOVER - The user must perform a HOVER gesture to 'Touch' by holding their hand still for a fixed time
 // PUSH - The user must perform a PUSH gesture to 'Touch' by pushing their hand toward the screen
 export enum InteractionType {
-  GRAB,
-  HOVER,
-  PUSH,
-  TOUCHPLANE,
-  VELOCITYSWIPE,
+    GRAB,
+    HOVER,
+    PUSH,
+    TOUCHPLANE,
+    VELOCITYSWIPE,
 }
 
 // Enum: TrackingServiceState
@@ -117,9 +117,9 @@ export enum InteractionType {
 // NO_CAMERA - The TouchFree service is connected to the tracking service but there is not a camera connected
 // CONNECTED - The TouchFree service is connected to the tracking service
 export enum TrackingServiceState {
-  UNAVAILABLE,
-  NO_CAMERA,
-  CONNECTED,
+    UNAVAILABLE,
+    NO_CAMERA,
+    CONNECTED,
 }
 
 // Enum: ConfigurationState
@@ -127,40 +127,40 @@ export enum TrackingServiceState {
 // LOADED - The TouchFree configuration has successfully been loaded
 // ERRORED - The TouchFree configuration errored on load
 export enum ConfigurationState {
-  NOT_LOADED,
-  LOADED,
-  ERRORED,
+    NOT_LOADED,
+    LOADED,
+    ERRORED,
 }
 
 // Enum: BitmaskFlags
 // This is used to request any combination of the <HandChiralities>, <HandTypes>, <InputTypes>,
 // and <InteractionTypes> flags from the Service at once.
 export enum BitmaskFlags {
-  NONE = 0,
+    NONE = 0,
 
-  // HandChirality
-  LEFT = 1,
-  RIGHT = 2,
+    // HandChirality
+    LEFT = 1,
+    RIGHT = 2,
 
-  // Hand Type
-  PRIMARY = 4,
-  SECONDARY = 8,
+    // Hand Type
+    PRIMARY = 4,
+    SECONDARY = 8,
 
-  // Input Types
-  NONE_INPUT = 16,
-  CANCEL = 32,
-  DOWN = 64,
-  MOVE = 128,
-  UP = 256,
+    // Input Types
+    NONE_INPUT = 16,
+    CANCEL = 32,
+    DOWN = 64,
+    MOVE = 128,
+    UP = 256,
 
-  // Interaction Types
-  GRAB = 512,
-  HOVER = 1024,
-  PUSH = 2048,
-  TOUCHPLANE = 4096,
-  VELOCITYSWIPE = 8192,
-  // Adding elements to this list is a breaking change, and should cause at
-  // least a minor iteration of the API version UNLESS adding them at the end
+    // Interaction Types
+    GRAB = 512,
+    HOVER = 1024,
+    PUSH = 2048,
+    TOUCHPLANE = 4096,
+    VELOCITYSWIPE = 8192,
+    // Adding elements to this list is a breaking change, and should cause at
+    // least a minor iteration of the API version UNLESS adding them at the end
 }
 
 // Enum: TouchFreeEvent
@@ -173,78 +173,74 @@ export enum BitmaskFlags {
 // TRANSMIT_INPUT_ACTION_RAW - Event dispatched directly from the <InputActionManager> without any proxying
 // TRANSMIT_INPUT_ACTION - Event dispatched from the <InputActionManager> to each registered Plugin
 export enum TouchFreeEvent {
-  ON_CONNECTED = "OnConnected",
-  ON_TRACKING_SERVICE_STATE_CHANGE = "OnTrackingServiceStateChange",
+    ON_CONNECTED = "OnConnected",
+    ON_TRACKING_SERVICE_STATE_CHANGE = "OnTrackingServiceStateChange",
 
-  HAND_FOUND = "HandFound",
-  HANDS_LOST = "HandsLost",
+    HAND_FOUND = "HandFound",
+    HANDS_LOST = "HandsLost",
 
-  INPUT_ACTION = "InputAction",
-  INPUT_ACTION_OUTPUT = "InputActionOutput",
+    INPUT_ACTION = "InputAction",
+    INPUT_ACTION_OUTPUT = "InputActionOutput",
 
-  TRAMSIT_INPUT_ACTION_RAW = "TransmitInputActionRaw",
-  TRAMSIT_INPUT_ACTION = "TransmitInputAction",
+    TRAMSIT_INPUT_ACTION_RAW = "TransmitInputActionRaw",
+    TRAMSIT_INPUT_ACTION = "TransmitInputAction",
 }
 
 // Class: WebsocketInputAction
 // The version of an InputAction received via the WebSocket. This must be converted into a
 // <TouchFreeInputAction> to be used by the Tooling and can be done so via ConvertInputAction.
 export class WebsocketInputAction {
-  // Variable: Timestamp
-  Timestamp: number;
-  // Variable: InteractionFlags
-  InteractionFlags: BitmaskFlags;
-  // Variable: CursorPosition
-  CursorPosition: any;
-  // Variable: DistanceFromScreen
-  DistanceFromScreen: number;
-  // Variable: ProgressToClick
-  ProgressToClick: number;
+    // Variable: Timestamp
+    Timestamp: number;
+    // Variable: InteractionFlags
+    InteractionFlags: BitmaskFlags;
+    // Variable: CursorPosition
+    CursorPosition: any;
+    // Variable: DistanceFromScreen
+    DistanceFromScreen: number;
+    // Variable: ProgressToClick
+    ProgressToClick: number;
 
-  constructor(
-    _timestamp: number,
-    _interactionFlags: BitmaskFlags,
-    _cursorPosition: any,
-    _distanceFromScreen: number,
-    _progressToClick: number,
-  ) {
-    this.Timestamp = _timestamp;
-    this.InteractionFlags = _interactionFlags;
-    this.CursorPosition = _cursorPosition;
-    this.DistanceFromScreen = _distanceFromScreen;
-    this.ProgressToClick = _progressToClick;
-  }
+    constructor(
+        _timestamp: number,
+        _interactionFlags: BitmaskFlags,
+        _cursorPosition: any,
+        _distanceFromScreen: number,
+        _progressToClick: number,
+    ) {
+        this.Timestamp = _timestamp;
+        this.InteractionFlags = _interactionFlags;
+        this.CursorPosition = _cursorPosition;
+        this.DistanceFromScreen = _distanceFromScreen;
+        this.ProgressToClick = _progressToClick;
+    }
 }
 
 // Class: HandFrame
 // A frame of hand data
-export class HandFrame
-{
+export class HandFrame {
     Hands: RawHand[] = [];
 }
 
 // Class: RawHand
 // The raw position data for a hand
-export class RawHand
-{
+export class RawHand {
     CurrentPrimary: boolean = false;
     Fingers: RawFinger[] = [];
     WristWidth: number = 0;
-    WristPosition: Vector = {X:0,Y:0,Z:0};
+    WristPosition: Vector = { X: 0, Y: 0, Z: 0 };
 }
 
 // Class: RawFinger
 // The raw position data for a finger of a hand
-export class RawFinger
-{
+export class RawFinger {
     Bones: RawBone[] = []
     Type: FingerType = FingerType.TYPE_UNKNOWN;
 }
 
 // Enum: FingerType
 // What finger on a hand a finger is.
-export enum FingerType
-{
+export enum FingerType {
     TYPE_THUMB = 0,
     TYPE_INDEX = 1,
     TYPE_MIDDLE = 2,
@@ -255,176 +251,175 @@ export enum FingerType
 
 // Class: RawFinger
 // The raw position data for a bone in a finger
-export class RawBone
-{
-    NextJoint: Vector = {X:0,Y:0,Z:0};
-    PrevJoint: Vector = {X:0,Y:0,Z:0};
+export class RawBone {
+    NextJoint: Vector = { X: 0, Y: 0, Z: 0 };
+    PrevJoint: Vector = { X: 0, Y: 0, Z: 0 };
 }
 
 // Class: FlagUtilities
 // A collection of Utilities to be used when working with <BitmaskFlags>.
 export class FlagUtilities {
-  // Group: Functions
+    // Group: Functions
 
-  // Function: GetInteractionFlags
-  // Used to convert a collection of interaction enums to flags for sending
-  // to the Service.
-  static GetInteractionFlags(
-    _interactionType: InteractionType,
-    _handType: HandType,
-    _chirality: HandChirality,
-    _inputType: InputType,
-  ): BitmaskFlags {
-    let returnVal: BitmaskFlags = BitmaskFlags.NONE;
+    // Function: GetInteractionFlags
+    // Used to convert a collection of interaction enums to flags for sending
+    // to the Service.
+    static GetInteractionFlags(
+        _interactionType: InteractionType,
+        _handType: HandType,
+        _chirality: HandChirality,
+        _inputType: InputType,
+    ): BitmaskFlags {
+        let returnVal: BitmaskFlags = BitmaskFlags.NONE;
 
-    switch (_handType) {
-      case HandType.PRIMARY:
-        returnVal ^= BitmaskFlags.PRIMARY;
-        break;
+        switch (_handType) {
+            case HandType.PRIMARY:
+                returnVal ^= BitmaskFlags.PRIMARY;
+                break;
 
-      case HandType.SECONDARY:
-        returnVal ^= BitmaskFlags.SECONDARY;
-        break;
+            case HandType.SECONDARY:
+                returnVal ^= BitmaskFlags.SECONDARY;
+                break;
+        }
+
+        switch (_chirality) {
+            case HandChirality.LEFT:
+                returnVal ^= BitmaskFlags.LEFT;
+                break;
+
+            case HandChirality.RIGHT:
+                returnVal ^= BitmaskFlags.RIGHT;
+                break;
+        }
+
+        switch (_inputType) {
+            case InputType.NONE:
+                returnVal ^= BitmaskFlags.NONE_INPUT;
+                break;
+
+            case InputType.CANCEL:
+                returnVal ^= BitmaskFlags.CANCEL;
+                break;
+
+            case InputType.MOVE:
+                returnVal ^= BitmaskFlags.MOVE;
+                break;
+
+            case InputType.UP:
+                returnVal ^= BitmaskFlags.UP;
+                break;
+
+            case InputType.DOWN:
+                returnVal ^= BitmaskFlags.DOWN;
+                break;
+        }
+
+        switch (_interactionType) {
+            case InteractionType.PUSH:
+                returnVal ^= BitmaskFlags.PUSH;
+                break;
+
+            case InteractionType.HOVER:
+                returnVal ^= BitmaskFlags.HOVER;
+                break;
+
+            case InteractionType.GRAB:
+                returnVal ^= BitmaskFlags.GRAB;
+                break;
+
+            case InteractionType.TOUCHPLANE:
+                returnVal ^= BitmaskFlags.TOUCHPLANE;
+                break;
+
+            case InteractionType.VELOCITYSWIPE:
+                returnVal ^= BitmaskFlags.VELOCITYSWIPE;
+                break;
+        }
+
+        return returnVal;
     }
 
-    switch (_chirality) {
-      case HandChirality.LEFT:
-        returnVal ^= BitmaskFlags.LEFT;
-        break;
+    // Function: GetChiralityFromFlags
+    // Used to find which <HandChirality> _flags contains. Favours RIGHT if none or both are found.
+    static GetChiralityFromFlags(_flags: BitmaskFlags): HandChirality {
+        let chirality: HandChirality = HandChirality.RIGHT;
 
-      case HandChirality.RIGHT:
-        returnVal ^= BitmaskFlags.RIGHT;
-        break;
+        if (_flags & BitmaskFlags.RIGHT) {
+            chirality = HandChirality.RIGHT;
+        } else if (_flags & BitmaskFlags.LEFT) {
+            chirality = HandChirality.LEFT;
+        } else {
+            console.error(
+                "InputActionData missing: No Chirality found. Defaulting to 'RIGHT'",
+            );
+        }
+
+        return chirality;
     }
 
-    switch (_inputType) {
-      case InputType.NONE:
-        returnVal ^= BitmaskFlags.NONE_INPUT;
-        break;
+    // Function: GetHandTypeFromFlags
+    // Used to find which <HandType> _flags contains. Favours PRIMARY if none or both are found.
+    static GetHandTypeFromFlags(_flags: BitmaskFlags): HandType {
+        let handType: HandType = HandType.PRIMARY;
 
-      case InputType.CANCEL:
-        returnVal ^= BitmaskFlags.CANCEL;
-        break;
+        if (_flags & BitmaskFlags.PRIMARY) {
+            handType = HandType.PRIMARY;
+        } else if (_flags & BitmaskFlags.SECONDARY) {
+            handType = HandType.SECONDARY;
+        } else {
+            console.error(
+                "InputActionData missing: No HandData found. Defaulting to 'PRIMARY'",
+            );
+        }
 
-      case InputType.MOVE:
-        returnVal ^= BitmaskFlags.MOVE;
-        break;
-
-      case InputType.UP:
-        returnVal ^= BitmaskFlags.UP;
-        break;
-
-      case InputType.DOWN:
-        returnVal ^= BitmaskFlags.DOWN;
-        break;
+        return handType;
     }
 
-    switch (_interactionType) {
-      case InteractionType.PUSH:
-        returnVal ^= BitmaskFlags.PUSH;
-        break;
+    // Function: GetInputTypeFromFlags
+    // Used to find which <InputType> _flags contains. Favours NONE if none are found.
+    static GetInputTypeFromFlags(_flags: BitmaskFlags): InputType {
+        let inputType: InputType = InputType.NONE;
 
-      case InteractionType.HOVER:
-        returnVal ^= BitmaskFlags.HOVER;
-        break;
+        if (_flags & BitmaskFlags.NONE_INPUT) {
+            inputType = InputType.NONE;
+        } else if (_flags & BitmaskFlags.CANCEL) {
+            inputType = InputType.CANCEL;
+        } else if (_flags & BitmaskFlags.UP) {
+            inputType = InputType.UP;
+        } else if (_flags & BitmaskFlags.DOWN) {
+            inputType = InputType.DOWN;
+        } else if (_flags & BitmaskFlags.MOVE) {
+            inputType = InputType.MOVE;
+        } else {
+            console.error(
+                "InputActionData missing: No InputType found. Defaulting to 'NONE'",
+            );
+        }
 
-      case InteractionType.GRAB:
-        returnVal ^= BitmaskFlags.GRAB;
-        break;
-
-      case InteractionType.TOUCHPLANE:
-        returnVal ^= BitmaskFlags.TOUCHPLANE;
-        break;
-
-      case InteractionType.VELOCITYSWIPE:
-        returnVal ^= BitmaskFlags.VELOCITYSWIPE;
-        break;
+        return inputType;
     }
 
-    return returnVal;
-  }
+    // Function: GetInteractionTypeFromFlags
+    // Used to find which <InteractionType> _flags contains. Favours PUSH if none are found.
+    static GetInteractionTypeFromFlags(_flags: BitmaskFlags): InteractionType {
+        let interactionType: InteractionType = InteractionType.PUSH;
 
-  // Function: GetChiralityFromFlags
-  // Used to find which <HandChirality> _flags contains. Favours RIGHT if none or both are found.
-  static GetChiralityFromFlags(_flags: BitmaskFlags): HandChirality {
-    let chirality: HandChirality = HandChirality.RIGHT;
+        if (_flags & BitmaskFlags.PUSH) {
+            interactionType = InteractionType.PUSH;
+        } else if (_flags & BitmaskFlags.HOVER) {
+            interactionType = InteractionType.HOVER;
+        } else if (_flags & BitmaskFlags.GRAB) {
+            interactionType = InteractionType.GRAB;
+        } else if (_flags & BitmaskFlags.TOUCHPLANE) {
+            interactionType = InteractionType.TOUCHPLANE;
+        } else if (_flags & BitmaskFlags.VELOCITYSWIPE) {
+            interactionType = InteractionType.VELOCITYSWIPE;
+        } else {
+            console.error(
+                "InputActionData missing: No InteractionType found. Defaulting to 'PUSH'",
+            );
+        }
 
-    if (_flags & BitmaskFlags.RIGHT) {
-      chirality = HandChirality.RIGHT;
-    } else if (_flags & BitmaskFlags.LEFT) {
-      chirality = HandChirality.LEFT;
-    } else {
-      console.error(
-        "InputActionData missing: No Chirality found. Defaulting to 'RIGHT'",
-      );
+        return interactionType;
     }
-
-    return chirality;
-  }
-
-  // Function: GetHandTypeFromFlags
-  // Used to find which <HandType> _flags contains. Favours PRIMARY if none or both are found.
-  static GetHandTypeFromFlags(_flags: BitmaskFlags): HandType {
-    let handType: HandType = HandType.PRIMARY;
-
-    if (_flags & BitmaskFlags.PRIMARY) {
-      handType = HandType.PRIMARY;
-    } else if (_flags & BitmaskFlags.SECONDARY) {
-      handType = HandType.SECONDARY;
-    } else {
-      console.error(
-        "InputActionData missing: No HandData found. Defaulting to 'PRIMARY'",
-      );
-    }
-
-    return handType;
-  }
-
-  // Function: GetInputTypeFromFlags
-  // Used to find which <InputType> _flags contains. Favours NONE if none are found.
-  static GetInputTypeFromFlags(_flags: BitmaskFlags): InputType {
-    let inputType: InputType = InputType.NONE;
-
-    if (_flags & BitmaskFlags.NONE_INPUT) {
-      inputType = InputType.NONE;
-    } else if (_flags & BitmaskFlags.CANCEL) {
-      inputType = InputType.CANCEL;
-    } else if (_flags & BitmaskFlags.UP) {
-      inputType = InputType.UP;
-    } else if (_flags & BitmaskFlags.DOWN) {
-      inputType = InputType.DOWN;
-    } else if (_flags & BitmaskFlags.MOVE) {
-      inputType = InputType.MOVE;
-    } else {
-      console.error(
-        "InputActionData missing: No InputType found. Defaulting to 'NONE'",
-      );
-    }
-
-    return inputType;
-  }
-
-  // Function: GetInteractionTypeFromFlags
-  // Used to find which <InteractionType> _flags contains. Favours PUSH if none are found.
-  static GetInteractionTypeFromFlags(_flags: BitmaskFlags): InteractionType {
-    let interactionType: InteractionType = InteractionType.PUSH;
-
-    if (_flags & BitmaskFlags.PUSH) {
-      interactionType = InteractionType.PUSH;
-    } else if (_flags & BitmaskFlags.HOVER) {
-      interactionType = InteractionType.HOVER;
-    } else if (_flags & BitmaskFlags.GRAB) {
-      interactionType = InteractionType.GRAB;
-    } else if (_flags & BitmaskFlags.TOUCHPLANE) {
-      interactionType = InteractionType.TOUCHPLANE;
-    } else if (_flags & BitmaskFlags.VELOCITYSWIPE) {
-      interactionType = InteractionType.VELOCITYSWIPE;
-    } else {
-      console.error(
-        "InputActionData missing: No InteractionType found. Defaulting to 'PUSH'",
-      );
-    }
-
-    return interactionType;
-  }
 }


### PR DESCRIPTION
- [x] Code Review
- [x] Developer Testing
- [x] QA Review
- [x] Test Plan updated
- [x] PO Review (Optional)
- [x] Update Release Notes

## Summary

Add connection status event to TouchFree Tooling and .NET Service.

### Changes

#### Service
I've sparingly made some changes that show language features I believe are helpful (which may be new to the reviewers) as well as some changes that are iterating towards improving the architecture of the overall product.

- `ClientConnectionManager` references `IConfigManager` and subscribes to `ConnectionManager.ServiceStatusChange` event through `IHandManager`.
- `ITrackingConnectionManager` now has getter and event for Service Status.
- Tidied up some of the implementation in `TrackingConnectionManager` and `HandManager`.
- Removed passthrough connection methods from `IHandManager` and replaced with a refence to `ITrackingConnectionManager`.
- Completed `IController` interface and replaced concrete `Controller` references.
- Added `Result<T>` for usage in `ITrackingDiagnosticAPI` events. `Result` is easier/safer to work with than nullable values with separate error messages.
- Modified members of `ITrackingDiagnosticAPI` to improve readability and remove implementation details.
- Refactored TrackingDiagnosticAPI implementation. This implementation will communicate relevant calls to the diagnostic API even when the device is disconnected when those calls are valid without a device connected. It now also caches config state itself and manages communicating this state to the diagnostic API when a device connects - pushing the values of "initialized" and pulling the values of "uninitialized" state. The behaviour of config state is as follows: "state set from client requests" > "state loaded from config" > "state existing on a device, retrieved when connected" > "default state value (uninitialized)". The Diagnostic API will save config state changes to file even when a device is disconnected if all values are initialized (e.g. there are none in the last state) - this behaviour is to avoid "state existing on a connected device" from getting overwritten by "loaded from config" in the case of default values.

Some further comments that I didn't do anything about:
- The chain of interfaces `IHandManager` -> `ITrackingConnectionManager` -> `IController` is curious. Including lower level interfaces via composition could be considered leaky abstraction but forwarding all of the calls on is not a reasonable solution to avoid it.
- Implementing the ability to save partial config files would allow simplifying the new implementation of Diagnostic API so that it doesn't have avoid saving to config unless all state is "initialized". It could just save only the initialized values.

#### Web Tooling

- Added `TouchFreeEvent` string enum to centralize event strings used for event listeners throughout tooling.
- Added an event dispatch from `ConnectionManager` for `TrackingServiceState` events that don't match up to a request id. These are assumed to be tracking service state changes that are pushed from the service.
- Added `AddServiceStatusListener` method to `ConnectionManager` for users to register to receive the service state dispatches mentioned above.

#### Web Settings

- Subscribe to `ServiceStatusListener` and replace polling behaviour with event. Service status will now update immediately upon device connection/disconnection.
- TouchFree Service Status is also passed through to `MaskingScreen` but nothing is done with it currently. Ideally it would update the UI in some way to show what actions cannot be performed due to device being disconnected.

## Issues Discovered/Still to fix

- Service will often crash when debugging due to incredibly long stack trace. More logging breakpoints seems to make it occur more often. Never ran into it when not debugging - seems to be performance sensitive. I suspect it's related to this issue https://github.com/sta/websocket-sharp/issues/702. Need to spend more time investigating.
- Masking screen will not read/save configuration until a device has been connected. I don't believe this is originating from the changed service Diagnostic API implementation. Does web settings/tooling prevent changes until status is connected? Same behaviour on develop - investigate separately.
- WebSocket exception usually occurs in service when refreshing web settings. `System.Net.WebSockets.WebSocketException (0x80004005): The remote party closed the WebSocket connection without completing the close handshake.` Easy to reproduce if required. Also happens on develop - should be investigated separately.
- Error when debugging web settings in debug console for `MaskingSliderDraggable`. Unsure if this is causing issues or not. Same behaviour on develop - investigate separately.
![image](https://user-images.githubusercontent.com/9743372/191303676-1f445a86-98ab-434a-8016-ab1437dfaf9a.png)
