### PR TITLE
Add WhenConnected and IsConnected

### DIFF
--- a/TF_Tooling_Web/src/Connection/ConnectionManager.ts
+++ b/TF_Tooling_Web/src/Connection/ConnectionManager.ts
@@ -66,15 +66,13 @@ export class ConnectionManager extends EventTarget {
     // Used to both add the _onConnectFunc action to the listeners of <OnConnected>
     // as well as auto-call the _onConnectFunc if a connection is already made.
     public static AddConnectionListener(_onConnectFunc: () => void): void {
-        TouchFree.RegisterEventCallback('OnConnected', _onConnectFunc);
+        TouchFree.RegisterEventCallback('WhenConnected', _onConnectFunc);
+    }
 
-        if (
-            ConnectionManager.currentServiceConnection !== null &&
-            ConnectionManager.currentServiceConnection.webSocket.readyState === WebSocket.OPEN &&
-            ConnectionManager.currentServiceConnection.handshakeComplete
-        ) {
-            _onConnectFunc();
-        }
+    public static get IsConnected():boolean {
+        return ConnectionManager.currentServiceConnection !== null &&
+        ConnectionManager.currentServiceConnection.webSocket.readyState === WebSocket.OPEN &&
+        ConnectionManager.currentServiceConnection.handshakeComplete;
     }
 
     public static AddServiceStatusListener(_serviceStatusFunc: (serviceStatus: TrackingServiceState) => void): void {

--- a/TF_Tooling_Web/src/TouchFree.ts
+++ b/TF_Tooling_Web/src/TouchFree.ts
@@ -33,6 +33,10 @@ const Init = (_tfInitParams?: TfInitParams): void => {
     });
 };
 
+// Function: IsConnected
+// Are we connected to the TouchFree service?
+const IsConnected = ():boolean => ConnectionManager.IsConnected;
+
 // Class: EventHandle
 // Object that can unregister a callback from an event
 // Returned when registering a callback to an event
@@ -40,36 +44,114 @@ export interface EventHandle {
     UnregisterEventCallback(): void;
 }
 
+// Turns a callback with an argument into a CustomEvent<T> Event Listener
 const MakeCustomEventWrapper = <T>(callback: (arg: T) => void): EventListener => {
     return ((evt: CustomEvent<T>) => {
         callback(evt.detail);
     }) as EventListener;
 };
 
-const EventTargets: { [T in TouchFreeEvent]: () => EventTarget } = {
-    HandFound: () => ConnectionManager.instance,
-    OnConnected: () => ConnectionManager.instance,
-    OnTrackingServiceStateChange: () => ConnectionManager.instance,
-    HandsLost: () => ConnectionManager.instance,
-    TransmitHandData: () => HandDataManager.instance,
-    InputAction: () => InputActionManager.instance,
-    TransmitInputActionRaw: () => InputActionManager.instance,
-    TransmitInputAction: () => InputActionManager.instance,
+// Signature required for RegisterEvent functions
+type RegisterEventFunc = (target:EventTarget, eventType:TouchFreeEvent, listener:EventListener) => EventHandle;
+
+// Default implementation of RegisterEvent
+const DefaultRegisterEventFunc:RegisterEventFunc = (target, eventType, listener) => {
+    target.addEventListener(eventType, listener);
+    return { UnregisterEventCallback: () => target.removeEventListener(eventType, listener) };
 };
 
-const EventListeners: { [T in TouchFreeEvent]: (callback: TouchFreeEventSignatures[T]) => EventListener } = {
-    // Map void functions, they can just be returned directly
-    OnConnected: (callback) => callback,
-    HandFound: (callback) => callback,
-    HandsLost: (callback) => callback,
+// Interface for each individual event's implementation details
+interface EventImpl<T extends TouchFreeEvent> {
+    Target: EventTarget;
+    WithCallback: (callback: TouchFreeEventSignatures[T]) => {
+        Listener: EventListener,
+        RegisterEventFunc: RegisterEventFunc
+    }
+}
 
-    // Callbacks with an argument need to be transformed to a function taking CustomEvent<T>
-    OnTrackingServiceStateChange: (callback) => MakeCustomEventWrapper(callback),
-    InputAction: (callback) => MakeCustomEventWrapper(callback),
-    TransmitHandData: (callback) => MakeCustomEventWrapper(callback),
-    TransmitInputActionRaw: (callback) => MakeCustomEventWrapper(callback),
-    TransmitInputAction: (callback) => MakeCustomEventWrapper(callback),
+type EventImpls = {
+    [T in TouchFreeEvent]: EventImpl<T>;
 };
+
+// Backing field to cache object creation
+let EventImplementationsBackingField: EventImpls | undefined;
+
+// Implementation details for all events
+// Any new events added to TouchFreeEvent require a new entry here to function
+const EventImplementations: () => EventImpls = () => EventImplementationsBackingField ??= ({
+    OnConnected: {
+        Target: ConnectionManager.instance,
+        WithCallback: (callback) => ({
+            Listener: callback, // Void callback can be returned directly
+            RegisterEventFunc: DefaultRegisterEventFunc
+        })
+    },
+    WhenConnected: {
+        Target: ConnectionManager.instance,
+        WithCallback: (callback) => ({
+            Listener: callback, // Void callback can be returned directly
+            RegisterEventFunc: (_target, _eventType, _listener) => {
+                // If we're already connected then run the callback
+                if (IsConnected())
+                {
+                    callback();
+                }
+
+                // Piggyback OnConnected
+                return RegisterEventCallback('OnConnected', callback);
+            }
+        })
+    },
+    OnTrackingServiceStateChange: {
+        Target: ConnectionManager.instance,
+        WithCallback: (callback) => ({
+            Listener: MakeCustomEventWrapper(callback),
+            RegisterEventFunc: DefaultRegisterEventFunc
+        })
+    },
+    HandFound: {
+        Target: ConnectionManager.instance,
+        WithCallback: (callback) => ({
+            Listener: callback, // Void callback can be returned directly
+            RegisterEventFunc: DefaultRegisterEventFunc
+        })
+    },
+    HandsLost: {
+        Target: ConnectionManager.instance,
+        WithCallback: (callback) => ({
+            Listener: callback, // Void callback can be returned directly
+            RegisterEventFunc: DefaultRegisterEventFunc
+        })
+    },
+    InputAction: {
+        Target: InputActionManager.instance,
+        WithCallback: (callback) => ({
+            Listener: MakeCustomEventWrapper(callback),
+            RegisterEventFunc: DefaultRegisterEventFunc
+        })
+    },
+    TransmitHandData: {
+        Target: HandDataManager.instance,
+        WithCallback: (callback) => ({
+            Listener: MakeCustomEventWrapper(callback),
+            RegisterEventFunc: DefaultRegisterEventFunc
+        })
+    },
+    TransmitInputAction: {
+        Target: InputActionManager.instance,
+        WithCallback: (callback) => ({
+            Listener: MakeCustomEventWrapper(callback),
+            RegisterEventFunc: DefaultRegisterEventFunc
+        })
+    },
+    TransmitInputActionRaw: {
+        Target: InputActionManager.instance,
+        WithCallback: (callback) => ({
+            Listener: MakeCustomEventWrapper(callback),
+            RegisterEventFunc: DefaultRegisterEventFunc
+        })
+    }
+});
 
 // Function: RegisterEventCallback
 // Registers a callback function to be called when a specific event occurs
@@ -79,6 +161,10 @@ const EventListeners: { [T in TouchFreeEvent]: (callback: TouchFreeEventSignatur
 //
 // OnConnected: () => void;
 // Event dispatched when connecting to the TouchFree service
+//
+// WhenConnected: () => void;
+// Same as OnConnected but calls callback when already connected.
+// Note this event piggybacks as an "OnConnected" event on event targets.
 //
 // OnTrackingServiceStateChange: (state: TrackingServiceState) => void;
 // Event dispatched when the connection between TouchFreeService and Ultraleap Tracking Service changes
@@ -104,11 +190,11 @@ const RegisterEventCallback = <TEvent extends TouchFreeEvent>(
     event: TEvent,
     callback: TouchFreeEventSignatures[TEvent]
 ): EventHandle => {
-    const eventType = event as TouchFreeEvent;
-    const target = EventTargets[event]();
-    const listener = EventListeners[event](callback);
-    target.addEventListener(eventType, listener);
-    return { UnregisterEventCallback: () => target.removeEventListener(eventType, listener) };
+    const eventImpl = EventImplementations()[event];
+    const target = eventImpl.Target;
+    const callbackImpl = eventImpl.WithCallback(callback);
+    const listener = callbackImpl.Listener;
+    return callbackImpl.RegisterEventFunc(target, event, listener);
 };
 
 // Function: DispatchEvent
@@ -125,16 +211,17 @@ const DispatchEvent = <TEvent extends TouchFreeEvent>(
         event = new CustomEvent(eventType, { detail: args[0] });
     }
 
-    const target = EventTargets[eventType]();
+    const target = EventImplementations()[eventType].Target;
     target.dispatchEvent(event);
 };
 
 // Bundle all our exports into a default object
 // Benefit to this is IDE autocomplete for "TouchFree" will find this object
 export default {
-    RegisterEventCallback,
+    CurrentCursor,
     DispatchEvent,
     Init,
-    CurrentCursor,
     InputController,
+    IsConnected,
+    RegisterEventCallback,
 };

--- a/TF_Tooling_Web/src/TouchFreeToolingTypes.ts
+++ b/TF_Tooling_Web/src/TouchFreeToolingTypes.ts
@@ -172,6 +172,7 @@ export enum BitmaskFlags {
 // TransmitInputAction - Event dispatched from the <InputActionManager> to each registered Plugin
 export interface TouchFreeEventSignatures {
     OnConnected: () => void;
+    WhenConnected: () => void;
     OnTrackingServiceStateChange: (state: TrackingServiceState) => void;
     HandFound: () => void;
     HandsLost: () => void;


### PR DESCRIPTION
## Summary

_Summary of the purpose of this pull request._

Resolves [TF-914](https://ultrahaptics.atlassian.net/browse/TF-914).
Add `WhenConnected` and `IsConnected` to TouchFree top level object.

Note that I've implemented `WhenConnected` to piggyback `OnConnected` rather than adding a separate named event.
This is simpler from implementation perspective than having a separate dispatch as the event is identical other the registration behaviour to invoke callback when already connected.

Also took some time to consolidate the implementation objects for events into a single lookup as I had to add a third lookup.

## Contributor Tasks

_These tasks are for the pull request creator to tick off._

- [x] Developer testing
- [ ] PO review (optional depending on work type)
- [ ] XDR review (optional depending on work type)
- [ ] QA review (or another developer if no QA is available)
- [x] Ensure documentation requirements are met e.g., public API is commented
- [x] Consider any licensing/other legal implications e.g., notices required

If there is an associated JIRA issue:
- [x] Include a link to the JIRA issue in the summary above
- [x] Update the release notes on the issue
- [x] Make sure the fix version on the issue is set correctly

## Reviewer Tasks

_Add any instructions or tasks for the reviewer such as specific test considerations before this can be merged._

- [x] Code reviewed
- [ ] Non-code assets reviewed
- [x] Documentation reviewed - includes checking documentation requirements are met and not missing e.g., public API is commented