### PR TITLE
TF-918 Setting timestamp format to en-GB

### DIFF
--- a/TF_Service_dotNet/TouchFree/Configuration/TouchFreeLog.cs
+++ b/TF_Service_dotNet/TouchFree/Configuration/TouchFreeLog.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 using System.IO;
 using System.Runtime.InteropServices;
 
@@ -55,7 +56,7 @@ namespace Ultraleap.TouchFree.Library.Configuration
         {
             if (!string.IsNullOrWhiteSpace(text))
             {
-                Console.WriteLine($"{DateTime.Now} - {text}");
+                Console.WriteLine($"{getTimestamp()} - {text}");
             }
             else
             {
@@ -67,12 +68,17 @@ namespace Ultraleap.TouchFree.Library.Configuration
         {
             if (!string.IsNullOrWhiteSpace(text))
             {
-                Console.Error.WriteLine($"{DateTime.Now} - {text}");
+                Console.Error.WriteLine($"{getTimestamp()} - {text}");
             }
             else
             {
                 Console.Error.WriteLine();
             }
+        }
+
+        private static string getTimestamp()
+        {
+            return DateTime.Now.ToString(new CultureInfo("en-GB"));
         }
     }
 }


### PR DESCRIPTION
## Summary

Change the logging date-time formatting to same as tracking logging. 

### Tests Added

Manual testing 
- tracking logging uses default formatting from spdlog
- Prior to pulling the change, change the Windows region format between English (UK) to English US and run from TouchFree_service app from the terminal. Note change of format. Pull update and repeat - timestamp format is no longer affected by host machine and fixed to UK time format.

## Contributor Tasks

_These tasks are for the pull request creator to tick off._

- [ ] PO review (optional depending on work type)
- [ ] XDR review (optional depending on work type)
- [ ] QA review (or another developer if no QA is available)
- [/] Ensure documentation requirements are met e.g., public API is commented - None applicable
- [/] Relevant changelogs have been updated with user-visible changes - None applicable
- [/] Consider any licensing/other legal implications e.g., notices required - None applicable

If there is an associated JIRA issue:
- [ ] Include a link to the JIRA issue in the summary above
- [ ] Make sure the fix version on the issue is set correctly

## Reviewer Tasks

_Add any instructions or tasks for the reviewer such as specific test considerations before this can be merged._

- [x] Developer testing
- [x] Code reviewed
- [x] Non-code assets reviewed
- [x] Documentation reviewed - includes checking documentation requirements are met and not missing e.g., public API is commented
