### PR TITLE
[TF-1141] Visuals Screen updates Cursor

### DIFF
--- a/TF_Settings_Web/src/Pages/Visuals/ColorPicker.tsx
+++ b/TF_Settings_Web/src/Pages/Visuals/ColorPicker.tsx
@@ -36,14 +36,22 @@ const ColorPicker: React.FC<ColorPickerProps> = ({ cursorStyle, updateCursorStyl
             <div className={'color-picker__body'}>
                 <HexAlphaColorPicker
                     color={cursorStyle[activeTabIndex]}
-                    onChange={(color) => updateCursorStyle({ ...cursorStyle, [activeTabIndex]: color })}
+                    onChange={(color) => {
+                        const newStyle: CursorStyle = [...cursorStyle];
+                        newStyle[activeTabIndex] = color;
+                        updateCursorStyle(newStyle);
+                    }}
                     onPointerUp={() => writeOutConfig()}
                 />
                 <input
                     type="text"
                     className={'color-picker__body__text'}
                     value={cursorStyle[activeTabIndex].toUpperCase()}
-                    onChange={(e) => updateCursorStyle({ ...cursorStyle, [activeTabIndex]: e.target.value })}
+                    onChange={(e) => {
+                        const newStyle: CursorStyle = [...cursorStyle];
+                        newStyle[activeTabIndex] = e.target.value;
+                        updateCursorStyle(newStyle);
+                    }}
                     onBlur={() => writeOutConfig()}
                     onKeyDown={(e) => {
                         if (e.key === 'Enter') {

--- a/TF_Settings_Web/src/Pages/Visuals/VisualsScreen.tsx
+++ b/TF_Settings_Web/src/Pages/Visuals/VisualsScreen.tsx
@@ -111,9 +111,9 @@ const VisualsScreen: React.FC = () => {
         <div className={classes('scroll-div')}>
             <label className={classes('label-container')}>
                 <p className={classes('label-container__label')}>
-                    Visuals affects Overlay application only.
+                    Visuals affects the TouchFree Overlay application only.
                     <br />
-                    To update the cursor in web, use TouchFree Tooling
+                    To update the cursor in your application, use TouchFree Tooling
                 </p>
                 <DocsLink title={'Find out More'} url={'https://developer.leapmotion.com/touchfree-tooling-for-web'} />
             </label>

--- a/TF_Settings_Web/src/Pages/Visuals/VisualsScreen.tsx
+++ b/TF_Settings_Web/src/Pages/Visuals/VisualsScreen.tsx
@@ -85,6 +85,7 @@ const VisualsScreen: React.FC = () => {
     }, [
         hasReadConfig,
         state.cursorEnabled,
+        state.activeCursorPreset,
         state.primaryCustomColor,
         state.secondaryCustomColor,
         state.tertiaryCustomColor,

--- a/TF_Settings_Web/src/Pages/Visuals/VisualsScreen.tsx
+++ b/TF_Settings_Web/src/Pages/Visuals/VisualsScreen.tsx
@@ -77,8 +77,14 @@ const VisualsScreen: React.FC = () => {
         section.setProperty('--outer-fill', cursorStyle[1]);
         section.setProperty('--center-border', cursorStyle[2]);
 
-        cursorStyle.forEach((value, index) => cursor.SetColor(index, value));
+        if (hasReadConfig && state.cursorEnabled) {
+            cursorStyle.forEach((value, index) => cursor.SetColor(index, value));
+        }
     };
+
+    useEffect(() => {
+        updateCursorStyle(cursorStyles[currentPreset]);
+    }, [hasReadConfig]);
 
     const currentPreset = useMemo((): CursorPreset => {
         return presets[state.activeCursorPreset];
@@ -90,7 +96,6 @@ const VisualsScreen: React.FC = () => {
                 dispatch({ content: fileConfig, writeOutConfig: false });
                 setCustomColorsFromConfig(fileConfig);
                 setHasReadConfig(true);
-                updateCursorStyle(cursorStyles[presets[fileConfig.activeCursorPreset]]);
             })
             .catch((err) => console.error(err));
 
@@ -124,7 +129,14 @@ const VisualsScreen: React.FC = () => {
                     <LabelledToggleSwitch
                         name="Enable Cursor"
                         value={state.cursorEnabled}
-                        onChange={(value) => dispatch({ content: { cursorEnabled: value }, writeOutConfig: true })}
+                        onChange={(value) => {
+                            dispatch({ content: { cursorEnabled: value }, writeOutConfig: true });
+                            if (!value) {
+                                cursor.ResetToDefaultColors();
+                            } else {
+                                cursorStyles[currentPreset].forEach((value, index) => cursor.SetColor(index, value));
+                            }
+                        }}
                     />
                     {state.cursorEnabled && (
                         <>

--- a/TF_Tooling_Web/.eslintrc.json
+++ b/TF_Tooling_Web/.eslintrc.json
@@ -66,7 +66,10 @@
                     "Impl",
                     "Impls",
                     "ts",
-                    "jsDom"
+                    "jsDom",
+                    "color",
+                    "colors",
+                    "colored"
                 ],
                 "skipWordIfMatch": ["^pointer.*$", "(\\S+(32|64)+)"],
                 "minLength": 3

--- a/TF_Tooling_Web/CHANGELOG.md
+++ b/TF_Tooling_Web/CHANGELOG.md
@@ -19,14 +19,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `IsConnected` function exported as part of the top level `TouchFree` object for querying whether or not the client is connected to the TouchFree Service.
 - `HandEntered` event disptached when the active hand enters the interaction zone (if enabled).
 - `HandExited` event disptached when the active hand exits the interaction zone (if enabled).
+- `SVGCursor.SetColor` allows you to set the color of the SVGCursor center fill, ring fill or center border.
+- `SVGCursor.ResetToDefaultColors` allows you reset the color of the entire SVGCursor back to it's default colors.
 
 ### Deprecated
 
 - `ConnectionManager.AddConnectionListener()` - functions identically to the `WhenConnected` event added this release and has been deprecated in favor of it.
 - `ConnectionManager.AddServiceStatusListener()` - functions identically to the `OnTrackingServiceStateChange` event and has been deprecated in favor of it.
-]
+  ]
 
 ### Fixed
+
 - Improved reliability of Scrolling with the WebInput Controller
 - Improved reliability of `touchfree-no-scroll` making elements unscrollable (with TouchFree Tooling)
 

--- a/TF_Tooling_Web/src/Cursors/SvgCursor.ts
+++ b/TF_Tooling_Web/src/Cursors/SvgCursor.ts
@@ -10,6 +10,7 @@ export class SVGCursor extends TouchlessCursor {
     private cursorRing: SVGCircleElement;
     private ringSizeMultiplier: number;
 
+    private isDarkCursor = false;
     private cursorShowing = false;
 
     // Group: Functions
@@ -17,11 +18,11 @@ export class SVGCursor extends TouchlessCursor {
     // Function: constructor
     // Constructs a new cursor consisting of a central cursor and a ring.
     // Optionally provide a ringSizeMultiplier to change the size that the <cursorRing> is relative to the _cursor.
-    // Optionally provide a darkCursor to change the cursor to be dark to provide better contrast on light coloured
+    // Optionally provide a darkCursor to change the cursor to be dark to provide better contrast on light colored
     // UIs.
     constructor(ringSizeMultiplier = 2, darkCursor = false) {
         super(undefined);
-
+        this.isDarkCursor = darkCursor;
         const documentBody = document.querySelector('body');
 
         const svgElement = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
@@ -44,7 +45,6 @@ export class SVGCursor extends TouchlessCursor {
         svgRingElement.setAttribute('r', '15');
         svgRingElement.setAttribute('fill-opacity', '0');
         svgRingElement.setAttribute('stroke-width', '5');
-        svgRingElement.setAttribute('stroke', darkCursor ? 'black' : 'white');
         svgRingElement.setAttribute(this.xPositionAttribute, '100');
         svgRingElement.setAttribute(this.yPositionAttribute, '100');
         svgRingElement.style.filter = 'drop-shadow(0 0 10px rgba(255, 255, 255, 0.7))';
@@ -55,7 +55,6 @@ export class SVGCursor extends TouchlessCursor {
         const svgDotElement = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
         svgDotElement.classList.add('touchfree-cursor');
         svgDotElement.setAttribute('r', '15');
-        svgDotElement.setAttribute('fill', darkCursor ? 'black' : 'white');
         svgDotElement.setAttribute(this.xPositionAttribute, '100');
         svgDotElement.setAttribute(this.yPositionAttribute, '100');
         svgDotElement.setAttribute('opacity', '1');
@@ -76,6 +75,8 @@ export class SVGCursor extends TouchlessCursor {
         this.cursor = svgDotElement;
 
         this.cursorCanvas = svgElement;
+
+        this.ResetToDefaultColors();
 
         this.ringSizeMultiplier = ringSizeMultiplier;
 
@@ -192,5 +193,36 @@ export class SVGCursor extends TouchlessCursor {
             return radiusAsNumber;
         }
         return 0;
+    }
+
+    // Function: SetDefaultColors
+    // Used to reset the SVGCursor to it's default styling
+    ResetToDefaultColors() {
+        this.cursor?.setAttribute('fill', this.isDarkCursor ? 'black' : 'white');
+        this.cursor?.removeAttribute('stroke-width');
+        this.cursor?.removeAttribute('stroke');
+        this.cursorRing.setAttribute('stroke', this.isDarkCursor ? 'black' : 'white');
+    }
+
+    // Function: SetColor
+    // Used to set a part of the SVGCursor to a specific color
+    // Takes a number to select the cursorPart where
+    //      0 = center fill
+    //      1 = ring fill
+    //      2 = center border
+    // and a color represented by a string
+    SetColor(cursorPart: number, color: string) {
+        switch (cursorPart) {
+            case 0:
+                this.cursor?.setAttribute('fill', color);
+                return;
+            case 1:
+                this.cursorRing.setAttribute('stroke', color);
+                return;
+            case 2:
+                this.cursor?.setAttribute('stroke', color);
+                this.cursor?.setAttribute('stroke-width', '2');
+                return;
+        }
     }
 }

--- a/TF_Tooling_Web/src/Cursors/SvgCursor.ts
+++ b/TF_Tooling_Web/src/Cursors/SvgCursor.ts
@@ -3,6 +3,12 @@ import { InputType, TouchFreeInputAction } from '../TouchFreeToolingTypes';
 import { MapRangeToRange } from '../Utilities';
 import { TouchlessCursor } from './TouchlessCursor';
 
+export const enum CursorPart {
+    CENTER_FILL,
+    RING_FILL,
+    CENTER_BORDER,
+}
+
 export class SVGCursor extends TouchlessCursor {
     private xPositionAttribute = 'cx';
     private yPositionAttribute = 'cy';
@@ -206,12 +212,8 @@ export class SVGCursor extends TouchlessCursor {
 
     // Function: SetColor
     // Used to set a part of the SVGCursor to a specific color
-    // Takes a number to select the cursorPart where
-    //      0 = center fill
-    //      1 = ring fill
-    //      2 = center border
-    // and a color represented by a string
-    SetColor(cursorPart: number, color: string) {
+    // Takes a CursorPart enum to select which part of the cursor to color and a color represented by a string
+    SetColor(cursorPart: CursorPart, color: string) {
         switch (cursorPart) {
             case 0:
                 this.cursor?.setAttribute('fill', color);

--- a/TF_Tooling_Web/src/Cursors/SvgCursor.ts
+++ b/TF_Tooling_Web/src/Cursors/SvgCursor.ts
@@ -215,13 +215,13 @@ export class SVGCursor extends TouchlessCursor {
     // Takes a CursorPart enum to select which part of the cursor to color and a color represented by a string
     SetColor(cursorPart: CursorPart, color: string) {
         switch (cursorPart) {
-            case 0:
+            case CursorPart.CENTER_FILL:
                 this.cursor?.setAttribute('fill', color);
                 return;
-            case 1:
+            case CursorPart.RING_FILL:
                 this.cursorRing.setAttribute('stroke', color);
                 return;
-            case 2:
+            case CursorPart.CENTER_BORDER:
                 this.cursor?.setAttribute('stroke', color);
                 this.cursor?.setAttribute('stroke-width', '2');
                 return;

--- a/TF_Tooling_Web/src/Cursors/tests/SvgCursor.test.ts
+++ b/TF_Tooling_Web/src/Cursors/tests/SvgCursor.test.ts
@@ -1,7 +1,7 @@
 import TouchFree from '../../TouchFree';
 import { InputType } from '../../TouchFreeToolingTypes';
 import { mockTfInputAction } from '../../tests/testUtils';
-import { SVGCursor } from '../SvgCursor';
+import { CursorPart, SVGCursor } from '../SvgCursor';
 
 TouchFree.Init();
 let svgCursor = new SVGCursor();
@@ -18,9 +18,9 @@ const checkDefaultCursorColors = (isDarkCursor = false) => {
 };
 
 const setNonDefaultCursorColors = () => {
-    svgCursor.SetColor(0, 'red');
-    svgCursor.SetColor(1, 'blue');
-    svgCursor.SetColor(2, 'green');
+    svgCursor.SetColor(CursorPart.CENTER_FILL, 'red');
+    svgCursor.SetColor(CursorPart.RING_FILL, 'blue');
+    svgCursor.SetColor(CursorPart.CENTER_BORDER, 'green');
     expect(cursorDot?.getAttribute('fill')).toBe('red');
     expect(cursorDot?.getAttribute('stroke')).toBe('green');
     expect(cursorDot?.getAttribute('stroke-width')).toBe('2');
@@ -142,19 +142,19 @@ describe('SVG Cursor', () => {
     test('SetColor should set the color of the correct cursor part', () => {
         checkDefaultCursorColors();
 
-        svgCursor.SetColor(0, 'red');
+        svgCursor.SetColor(CursorPart.CENTER_FILL, 'red');
         expect(cursorDot?.getAttribute('fill')).toBe('red');
         expect(cursorDot?.getAttribute('stroke')).toBe(null);
         expect(cursorDot?.getAttribute('stroke-width')).toBe(null);
         expect(cursorRing?.getAttribute('stroke')).toBe('white');
 
-        svgCursor.SetColor(1, 'blue');
+        svgCursor.SetColor(CursorPart.RING_FILL, 'blue');
         expect(cursorDot?.getAttribute('fill')).toBe('red');
         expect(cursorDot?.getAttribute('stroke')).toBe(null);
         expect(cursorDot?.getAttribute('stroke-width')).toBe(null);
         expect(cursorRing?.getAttribute('stroke')).toBe('blue');
 
-        svgCursor.SetColor(2, 'green');
+        svgCursor.SetColor(CursorPart.CENTER_BORDER, 'green');
         expect(cursorDot?.getAttribute('fill')).toBe('red');
         expect(cursorDot?.getAttribute('stroke')).toBe('green');
         expect(cursorDot?.getAttribute('stroke-width')).toBe('2');

--- a/TF_Tooling_Web/src/Cursors/tests/SvgCursor.test.ts
+++ b/TF_Tooling_Web/src/Cursors/tests/SvgCursor.test.ts
@@ -4,18 +4,19 @@ import { mockTfInputAction } from '../../tests/testUtils';
 import { SVGCursor } from '../SvgCursor';
 
 TouchFree.Init();
-const svgCursor = new SVGCursor();
-const cursor = document.getElementById('svg-cursor');
-const cursorRing = document.getElementById('svg-cursor-ring');
-const cursorDot = document.getElementById('svg-cursor-dot');
+let svgCursor = new SVGCursor();
+let cursor = document.getElementById('svg-cursor');
+let cursorRing = document.getElementById('svg-cursor-ring');
+let cursorDot = document.getElementById('svg-cursor-dot');
 
 describe('SVG Cursor', () => {
-    beforeAll(() => {
+    beforeEach(() => {
         // Set cursor to known state before each test
         mockTfInputAction();
         mockTfInputAction({ InputType: InputType.UP });
         svgCursor.EnableCursor();
         svgCursor.ShowCursor();
+        svgCursor.ResetToDefaultColors();
     });
 
     test('Creates a cursor in the document body', () => {
@@ -118,5 +119,92 @@ describe('SVG Cursor', () => {
         expect(cursor?.style.opacity).toBe('0');
         svgCursor.ShowCursor();
         expect(cursor?.style.opacity).toBe('0.4');
+    });
+
+    test('SetColor should set the color of the correct cursor part', () => {
+        expect(cursorDot?.getAttribute('fill')).toBe('white');
+        expect(cursorDot?.getAttribute('stroke')).toBe(null);
+        expect(cursorDot?.getAttribute('stroke-width')).toBe(null);
+        expect(cursorRing?.getAttribute('stroke')).toBe('white');
+
+        svgCursor.SetColor(0, 'red');
+        expect(cursorDot?.getAttribute('fill')).toBe('red');
+        expect(cursorDot?.getAttribute('stroke')).toBe(null);
+        expect(cursorDot?.getAttribute('stroke-width')).toBe(null);
+        expect(cursorRing?.getAttribute('stroke')).toBe('white');
+
+        svgCursor.SetColor(1, 'blue');
+        expect(cursorDot?.getAttribute('fill')).toBe('red');
+        expect(cursorDot?.getAttribute('stroke')).toBe(null);
+        expect(cursorDot?.getAttribute('stroke-width')).toBe(null);
+        expect(cursorRing?.getAttribute('stroke')).toBe('blue');
+
+        svgCursor.SetColor(2, 'green');
+        expect(cursorDot?.getAttribute('fill')).toBe('red');
+        expect(cursorDot?.getAttribute('stroke')).toBe('green');
+        expect(cursorDot?.getAttribute('stroke-width')).toBe('2');
+        expect(cursorRing?.getAttribute('stroke')).toBe('blue');
+    });
+
+    test('ResetToDefaultColors should reset the cursor colors', () => {
+        expect(cursorDot?.getAttribute('fill')).toBe('white');
+        expect(cursorDot?.getAttribute('stroke')).toBe(null);
+        expect(cursorDot?.getAttribute('stroke-width')).toBe(null);
+        expect(cursorRing?.getAttribute('stroke')).toBe('white');
+
+        svgCursor.SetColor(0, 'red');
+        svgCursor.SetColor(1, 'blue');
+        svgCursor.SetColor(2, 'green');
+        expect(cursorDot?.getAttribute('fill')).toBe('red');
+        expect(cursorDot?.getAttribute('stroke')).toBe('green');
+        expect(cursorDot?.getAttribute('stroke-width')).toBe('2');
+        expect(cursorRing?.getAttribute('stroke')).toBe('blue');
+
+        svgCursor.ResetToDefaultColors();
+        expect(cursorDot?.getAttribute('fill')).toBe('white');
+        expect(cursorDot?.getAttribute('stroke')).toBe(null);
+        expect(cursorDot?.getAttribute('stroke-width')).toBe(null);
+        expect(cursorRing?.getAttribute('stroke')).toBe('white');
+    });
+
+    describe('SVG Cursor darkCursor', () => {
+        beforeAll(() => {
+            cursor?.remove();
+            cursorDot?.remove();
+            cursorRing?.remove();
+
+            svgCursor = new SVGCursor(2, true);
+            cursor = document.getElementById('svg-cursor');
+            cursorRing = document.getElementById('svg-cursor-ring');
+            cursorDot = document.getElementById('svg-cursor-dot');
+        });
+
+        test('Cursor has the correct colors with darkCursor set', () => {
+            expect(cursorDot?.getAttribute('fill')).toBe('black');
+            expect(cursorDot?.getAttribute('stroke')).toBe(null);
+            expect(cursorDot?.getAttribute('stroke-width')).toBe(null);
+            expect(cursorRing?.getAttribute('stroke')).toBe('black');
+        });
+
+        test('ResetToDefaultColors should reset the cursor colors', () => {
+            expect(cursorDot?.getAttribute('fill')).toBe('black');
+            expect(cursorDot?.getAttribute('stroke')).toBe(null);
+            expect(cursorDot?.getAttribute('stroke-width')).toBe(null);
+            expect(cursorRing?.getAttribute('stroke')).toBe('black');
+
+            svgCursor.SetColor(0, 'red');
+            svgCursor.SetColor(1, 'blue');
+            svgCursor.SetColor(2, 'green');
+            expect(cursorDot?.getAttribute('fill')).toBe('red');
+            expect(cursorDot?.getAttribute('stroke')).toBe('green');
+            expect(cursorDot?.getAttribute('stroke-width')).toBe('2');
+            expect(cursorRing?.getAttribute('stroke')).toBe('blue');
+
+            svgCursor.ResetToDefaultColors();
+            expect(cursorDot?.getAttribute('fill')).toBe('black');
+            expect(cursorDot?.getAttribute('stroke')).toBe(null);
+            expect(cursorDot?.getAttribute('stroke-width')).toBe(null);
+            expect(cursorRing?.getAttribute('stroke')).toBe('black');
+        });
     });
 });

--- a/TF_Tooling_Web/src/Cursors/tests/SvgCursor.test.ts
+++ b/TF_Tooling_Web/src/Cursors/tests/SvgCursor.test.ts
@@ -9,6 +9,24 @@ let cursor = document.getElementById('svg-cursor');
 let cursorRing = document.getElementById('svg-cursor-ring');
 let cursorDot = document.getElementById('svg-cursor-dot');
 
+const checkDefaultCursorColors = (isDarkCursor = false) => {
+    const baseColor = isDarkCursor ? 'black' : 'white';
+    expect(cursorDot?.getAttribute('fill')).toBe(baseColor);
+    expect(cursorDot?.getAttribute('stroke')).toBe(null);
+    expect(cursorDot?.getAttribute('stroke-width')).toBe(null);
+    expect(cursorRing?.getAttribute('stroke')).toBe(baseColor);
+};
+
+const setNonDefaultCursorColors = () => {
+    svgCursor.SetColor(0, 'red');
+    svgCursor.SetColor(1, 'blue');
+    svgCursor.SetColor(2, 'green');
+    expect(cursorDot?.getAttribute('fill')).toBe('red');
+    expect(cursorDot?.getAttribute('stroke')).toBe('green');
+    expect(cursorDot?.getAttribute('stroke-width')).toBe('2');
+    expect(cursorRing?.getAttribute('stroke')).toBe('blue');
+};
+
 describe('SVG Cursor', () => {
     beforeEach(() => {
         // Set cursor to known state before each test
@@ -122,10 +140,7 @@ describe('SVG Cursor', () => {
     });
 
     test('SetColor should set the color of the correct cursor part', () => {
-        expect(cursorDot?.getAttribute('fill')).toBe('white');
-        expect(cursorDot?.getAttribute('stroke')).toBe(null);
-        expect(cursorDot?.getAttribute('stroke-width')).toBe(null);
-        expect(cursorRing?.getAttribute('stroke')).toBe('white');
+        checkDefaultCursorColors();
 
         svgCursor.SetColor(0, 'red');
         expect(cursorDot?.getAttribute('fill')).toBe('red');
@@ -147,24 +162,11 @@ describe('SVG Cursor', () => {
     });
 
     test('ResetToDefaultColors should reset the cursor colors', () => {
-        expect(cursorDot?.getAttribute('fill')).toBe('white');
-        expect(cursorDot?.getAttribute('stroke')).toBe(null);
-        expect(cursorDot?.getAttribute('stroke-width')).toBe(null);
-        expect(cursorRing?.getAttribute('stroke')).toBe('white');
-
-        svgCursor.SetColor(0, 'red');
-        svgCursor.SetColor(1, 'blue');
-        svgCursor.SetColor(2, 'green');
-        expect(cursorDot?.getAttribute('fill')).toBe('red');
-        expect(cursorDot?.getAttribute('stroke')).toBe('green');
-        expect(cursorDot?.getAttribute('stroke-width')).toBe('2');
-        expect(cursorRing?.getAttribute('stroke')).toBe('blue');
+        checkDefaultCursorColors();
+        setNonDefaultCursorColors();
 
         svgCursor.ResetToDefaultColors();
-        expect(cursorDot?.getAttribute('fill')).toBe('white');
-        expect(cursorDot?.getAttribute('stroke')).toBe(null);
-        expect(cursorDot?.getAttribute('stroke-width')).toBe(null);
-        expect(cursorRing?.getAttribute('stroke')).toBe('white');
+        checkDefaultCursorColors();
     });
 
     describe('SVG Cursor darkCursor', () => {
@@ -180,31 +182,15 @@ describe('SVG Cursor', () => {
         });
 
         test('Cursor has the correct colors with darkCursor set', () => {
-            expect(cursorDot?.getAttribute('fill')).toBe('black');
-            expect(cursorDot?.getAttribute('stroke')).toBe(null);
-            expect(cursorDot?.getAttribute('stroke-width')).toBe(null);
-            expect(cursorRing?.getAttribute('stroke')).toBe('black');
+            checkDefaultCursorColors(true);
         });
 
         test('ResetToDefaultColors should reset the cursor colors', () => {
-            expect(cursorDot?.getAttribute('fill')).toBe('black');
-            expect(cursorDot?.getAttribute('stroke')).toBe(null);
-            expect(cursorDot?.getAttribute('stroke-width')).toBe(null);
-            expect(cursorRing?.getAttribute('stroke')).toBe('black');
-
-            svgCursor.SetColor(0, 'red');
-            svgCursor.SetColor(1, 'blue');
-            svgCursor.SetColor(2, 'green');
-            expect(cursorDot?.getAttribute('fill')).toBe('red');
-            expect(cursorDot?.getAttribute('stroke')).toBe('green');
-            expect(cursorDot?.getAttribute('stroke-width')).toBe('2');
-            expect(cursorRing?.getAttribute('stroke')).toBe('blue');
+            checkDefaultCursorColors(true);
+            setNonDefaultCursorColors();
 
             svgCursor.ResetToDefaultColors();
-            expect(cursorDot?.getAttribute('fill')).toBe('black');
-            expect(cursorDot?.getAttribute('stroke')).toBe(null);
-            expect(cursorDot?.getAttribute('stroke-width')).toBe(null);
-            expect(cursorRing?.getAttribute('stroke')).toBe('black');
+            checkDefaultCursorColors(true);
         });
     });
 });


### PR DESCRIPTION
## Summary

The TouchFree cursor on the Visuals screen should be colored the same as the Overlay Cursor and update as the pre-set and custom color settings on the Visuals screen are altered. 

Should revert to the normal cursor colors when leaving the Visuals tab or when the Visuals cursor is not enabled

https://ultrahaptics.atlassian.net/browse/TF-1141

### Tests Added

Added unit tests for the new SVGCursor methods
 Update [Zephyr test](https://ultrahaptics.atlassian.net/projects/TF?selectedItem=com.atlassian.plugins.atlassian-connect-plugin:com.kanoah.test-manager__main-project-page#!/testCase/TF-T441) to test that the cursor color updates


## Contributor Tasks

_These tasks are for the pull request creator to tick off._

- [ ] PO review (optional depending on work type)
- [ ] XDR review (optional depending on work type)
- [ ] QA review (or another developer if no QA is available)
- [x] Ensure documentation requirements are met e.g., public API is commented
- [x] Relevant changelogs have been updated with user-visible changes
    - [ ] [TouchFree Windows](/ultraleap/touchfree/blob/-/CHANGELOG-windows.md)
    - [ ] [TouchFree BrightSign](/ultraleap/touchfree/blob/-/CHANGELOG-brightsign.md)
    - [x] [TouchFree Web Tooling](/ultraleap/touchfree/blob/-/TF_Tooling_Web/CHANGELOG.md)
- [x] Consider any licensing/other legal implications e.g., notices required

If there is an associated JIRA issue:
- [x] Include a link to the JIRA issue in the summary above
- [x] Make sure the fix version on the issue is set correctly

## Reviewer Tasks

_Add any instructions or tasks for the reviewer such as specific test considerations before this can be merged._

- [x] Developer testing
- [x] Code reviewed
- [x] Non-code assets reviewed
- [x] Documentation reviewed - includes checking documentation requirements are met and not missing e.g., public API is commented
