### PR TITLE
[TF-1152] - Handle invalid hex inputs in Visuals Screen

### DIFF
--- a/TF_Settings_Web/src/Pages/Visuals/ColorPicker.tsx
+++ b/TF_Settings_Web/src/Pages/Visuals/ColorPicker.tsx
@@ -1,7 +1,8 @@
 import './ColorPicker.scss';
 
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { HexAlphaColorPicker } from 'react-colorful';
+import tinycolor from 'tinycolor2';
 
 import { TabSelector } from '@/Components/Header';
 
@@ -17,6 +18,9 @@ const cursorSections = ['Center Fill', 'Outer Fill', 'Center Border'] as const;
 
 const ColorPicker: React.FC<ColorPickerProps> = ({ cursorStyle, updateCursorStyle, writeOutConfig }) => {
     const [activeTabIndex, setActiveTabIndex] = useState<number>(0);
+    const [localHex, setLocalHex] = useState<string>(cursorStyle[activeTabIndex]);
+
+    useEffect(() => setLocalHex(cursorStyle[activeTabIndex]), [cursorStyle, activeTabIndex]);
 
     return (
         <div className={'color-picker'}>
@@ -46,10 +50,15 @@ const ColorPicker: React.FC<ColorPickerProps> = ({ cursorStyle, updateCursorStyl
                 <input
                     type="text"
                     className={'color-picker__body__text'}
-                    value={cursorStyle[activeTabIndex].toUpperCase()}
+                    value={localHex.toUpperCase()}
                     onChange={(e) => {
+                        const color = e.target.value;
+                        if (!tinycolor(color).isValid()) {
+                            setLocalHex(color);
+                            return;
+                        }
                         const newStyle: CursorStyle = [...cursorStyle];
-                        newStyle[activeTabIndex] = e.target.value;
+                        newStyle[activeTabIndex] = color;
                         updateCursorStyle(newStyle);
                     }}
                     onBlur={() => writeOutConfig()}


### PR DESCRIPTION
## Summary

Fix an issue where if you entered an invalid hex into the custom color hex string input in the Web Settings visual screen the UI would display a best guess color while the config would use black for any invalid hex.

Now the UI and config will only update on valid hex inputs so they remain in sync

https://ultrahaptics.atlassian.net/browse/TF-1152

### Tests Added

Updated [Visual Screen zephyr test plan](https://ultrahaptics.atlassian.net/projects/TF?selectedItem=com.atlassian.plugins.atlassian-connect-plugin:com.kanoah.test-manager__main-project-page#!/testCase/TF-T441)


## Contributor Tasks

_These tasks are for the pull request creator to tick off._

- [ ] PO review (optional depending on work type)
- [ ] XDR review (optional depending on work type)
- [x] QA review (or another developer if no QA is available)
- [x] Ensure documentation requirements are met e.g., public API is commented
- [x] Relevant changelogs have been updated with user-visible changes
    - [ ] [TouchFree Windows](/ultraleap/touchfree/blob/-/CHANGELOG-windows.md)
    - [ ] [TouchFree BrightSign](/ultraleap/touchfree/blob/-/CHANGELOG-brightsign.md)
    - [ ] [TouchFree Web Tooling](/ultraleap/touchfree/blob/-/TF_Tooling_Web/CHANGELOG.md)
- [x] Consider any licensing/other legal implications e.g., notices required

If there is an associated JIRA issue:
- [x] Include a link to the JIRA issue in the summary above
- [x] Make sure the fix version on the issue is set correctly

## Reviewer Tasks

_Add any instructions or tasks for the reviewer such as specific test considerations before this can be merged._

- [x] Developer testing
- [x] Code reviewed
- [ ] Non-code assets reviewed
- [ ] Documentation reviewed - includes checking documentation requirements are met and not missing e.g., public API is commented
