### PR TITLE
Move settings exe to base of build archive

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -382,6 +382,7 @@ TF_Settings::Web::build:
     - npm ls
     - cd ./TF_Settings_Web
     - npm run tauri build
+    - mv ./src-tauri/target/release/*.exe ./
     # npm workspaces cause the Web Settings node modules to be installed in the root folder so need to copy the Web Settings' package.json up a level
     # so it's at the same level as the node modules
     - cp ./package.json ../
@@ -397,7 +398,7 @@ TF_Settings::Web::build:
     name: "TouchFree_Settings_Web_${env:TOUCHFREE_VERSION}_${env:CI_COMMIT_SHORT_SHA}"
     paths:
     - ./TF_Settings_Web/dist/*
-    - ./TF_Settings_Web/src-tauri/target/release/*.exe
+    - ./TF_Settings_Web/touchfree-settings-web.exe
     expire_in: 2 weeks
     when: always
   tags:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -393,7 +393,7 @@ TF_Settings::Web::build:
         exit 1
       }
     - azuresigntool sign -du "https://www.ultraleap.com" -kvu "https://$env:SIGN_VAULT_ID.vault.azure.net/"  -kvi "$env:SIGN_VAULT_APPLICATION_ID" -kvs "$env:SIGN_VAULT_APPLICATION_CLIENT_CODE" -kvc "ultraleap-ltd" -kvt "$env:SIGN_VAULT_TENANT_ID" -tr http://timestamp.digicert.com -v "$CI_PROJECT_DIR/TF_Settings_Web/src-tauri/target/release/touchfree-settings-web.exe"
-    - mv ./TF_Settings_Web/src-tauri/target/release/*.exe ./
+    - mv $CI_PROJECT_DIR/TF_Settings_Web/src-tauri/target/release/*.exe $CI_PROJECT_DIR/TF_Settings_Web/
   artifacts:
     name: "TouchFree_Settings_Web_${env:TOUCHFREE_VERSION}_${env:CI_COMMIT_SHORT_SHA}"
     paths:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -382,7 +382,6 @@ TF_Settings::Web::build:
     - npm ls
     - cd ./TF_Settings_Web
     - npm run tauri build
-    - mv ./src-tauri/target/release/*.exe ./
     # npm workspaces cause the Web Settings node modules to be installed in the root folder so need to copy the Web Settings' package.json up a level
     # so it's at the same level as the node modules
     - cp ./package.json ../
@@ -394,11 +393,12 @@ TF_Settings::Web::build:
         exit 1
       }
     - azuresigntool sign -du "https://www.ultraleap.com" -kvu "https://$env:SIGN_VAULT_ID.vault.azure.net/"  -kvi "$env:SIGN_VAULT_APPLICATION_ID" -kvs "$env:SIGN_VAULT_APPLICATION_CLIENT_CODE" -kvc "ultraleap-ltd" -kvt "$env:SIGN_VAULT_TENANT_ID" -tr http://timestamp.digicert.com -v "$CI_PROJECT_DIR/TF_Settings_Web/src-tauri/target/release/touchfree-settings-web.exe"
+    - mv ./TF_Settings_Web/src-tauri/target/release/*.exe ./
   artifacts:
     name: "TouchFree_Settings_Web_${env:TOUCHFREE_VERSION}_${env:CI_COMMIT_SHORT_SHA}"
     paths:
     - ./TF_Settings_Web/dist/*
-    - ./TF_Settings_Web/touchfree-settings-web.exe
+    - ./TF_Settings_Web/*.exe
     expire_in: 2 weeks
     when: always
   tags:


### PR DESCRIPTION
## Summary

Move settings exe to base of build archive rather than keeping it in three layers of directories.

## Contributor Tasks

_These tasks are for the pull request creator to tick off._

- [ ] Relevant changelogs have been updated with user-visible changes
    - [ ] [TouchFree Windows](/ultraleap/touchfree/blob/-/CHANGELOG-windows.md)
    - [ ] [TouchFree BrightSign](/ultraleap/touchfree/blob/-/CHANGELOG-brightsign.md)
    - [ ] [TouchFree Web Tooling](/ultraleap/touchfree/blob/-/TF_Tooling_Web/CHANGELOG.md)

## Reviewer Tasks

_Add any instructions or tasks for the reviewer such as specific test considerations before this can be merged._

- [x] Developer testing
- [x] Code reviewed
- [ ] Non-code assets reviewed
- [ ] Documentation reviewed - includes checking documentation requirements are met and not missing e.g., public API is commented