### PR TITLE
[TF-1144] Disable Overlay cursor when settings app is running

### DIFF
--- a/TF_Settings_Web/src-tauri/tauri.conf.json
+++ b/TF_Settings_Web/src-tauri/tauri.conf.json
@@ -68,7 +68,7 @@
         },
         "windows": [
             {
-                "title": "TouchFree Settings",
+                "title": "TouchFreeSettings",
                 "fullscreen": true,
                 "maximized": true,
                 "resizable": true


### PR DESCRIPTION
## Summary

Disable Overlay cursor when settings app is running in order to not display two cursors in settings.

Closes [TF-1144](https://ultrahaptics.atlassian.net/browse/TF-1144)


### Tests Added

Zephyr test added.


## Contributor Tasks

_These tasks are for the pull request creator to tick off._

- [ ] ~PO review (optional depending on work type)~
- [ ] ~XDR review (optional depending on work type)~
- [ ] QA review (or another developer if no QA is available)
- [ ] ~Ensure documentation requirements are met e.g., public API is commented~
- [ ] ~Relevant changelogs have been updated with user-visible changes~
    - [ ] ~[TouchFree Windows](/ultraleap/touchfree/blob/-/CHANGELOG-windows.md)~
    - [ ] ~[TouchFree BrightSign](/ultraleap/touchfree/blob/-/CHANGELOG-brightsign.md)~
    - [ ] ~[TouchFree Web Tooling](/ultraleap/touchfree/blob/-/TF_Tooling_Web/CHANGELOG.md)~
- [x] Consider any licensing/other legal implications e.g., notices required

If there is an associated JIRA issue:
- [x] Include a link to the JIRA issue in the summary above
- [ ] Make sure the fix version on the issue is set correctly

## Reviewer Tasks

_Add any instructions or tasks for the reviewer such as specific test considerations before this can be merged._

- [ ] Developer testing
- [ ] Code reviewed
- [ ] Non-code assets reviewed
- [ ] Documentation reviewed - includes checking documentation requirements are met and not missing e.g., public API is commented


[TF-1144]: https://ultrahaptics.atlassian.net/browse/TF-1144?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ