### PR TITLE
Allow window resizing in Unity settings

### DIFF
--- a/CHANGELOG-windows.md
+++ b/CHANGELOG-windows.md
@@ -29,6 +29,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Service: `HandEntered` & `HandExited` events, sent when the active hand enters and exits the interaction zone (if enabled) respectively
 - Service: Removed informational level logging to improve readability of log files
 
+### Changed
+- Unity Settings: Allow resizing of window when in windowed mode
+
 ### Fixed
 
 - Unity Settings/Service: Fixed an issue where using Touch Plane with Scroll and Drag caused cursor jumps

--- a/TF_Settings_and_Tooling_Unity/ProjectSettings/ProjectSettings.asset
+++ b/TF_Settings_and_Tooling_Unity/ProjectSettings/ProjectSettings.asset
@@ -80,7 +80,7 @@ PlayerSettings:
   bakeCollisionMeshes: 0
   forceSingleInstance: 1
   useFlipModelSwapchain: 1
-  resizableWindow: 0
+  resizableWindow: 1
   useMacAppStoreValidation: 0
   macAppStoreCategory: public.app-category.games
   gpuSkinning: 1


### PR DESCRIPTION
## Summary

When using windowed mode in the Unity settings (ALT+ENTER), you can now resize the window manually. Useful for users with ultrawide displays.

https://ultrahaptics.atlassian.net/browse/TF-1153


## Contributor Tasks

_These tasks are for the pull request creator to tick off._

- [ ] PO review (optional depending on work type)
- [ ] XDR review (optional depending on work type)
- [ ] QA review (or another developer if no QA is available)
- [ ] Ensure documentation requirements are met e.g., public API is commented
- [x] Relevant changelogs have been updated with user-visible changes
    - [x] [TouchFree Windows](/ultraleap/touchfree/blob/-/CHANGELOG-windows.md)
    - [ ] [TouchFree BrightSign](/ultraleap/touchfree/blob/-/CHANGELOG-brightsign.md)
    - [ ] [TouchFree Web Tooling](/ultraleap/touchfree/blob/-/TF_Tooling_Web/CHANGELOG.md)
- [ ] Consider any licensing/other legal implications e.g., notices required

If there is an associated JIRA issue:
- [x] Include a link to the JIRA issue in the summary above
- [ ] Make sure the fix version on the issue is set correctly

## Reviewer Tasks

_Add any instructions or tasks for the reviewer such as specific test considerations before this can be merged._

- [ ] Developer testing
- [x] Code reviewed
- [x] Non-code assets reviewed
- [x] Documentation reviewed - includes checking documentation requirements are met and not missing e.g., public API is commented
