### PR TITLE
Correctly reload alpha values in web custom cursor config

### DIFF
--- a/TF_Settings_Web/src/Pages/Visuals/VisualsScreen.tsx
+++ b/TF_Settings_Web/src/Pages/Visuals/VisualsScreen.tsx
@@ -258,7 +258,7 @@ const roundToTwoDP = (numberIn: number) => Math.round(numberIn * 100) / 100;
 const setCustomColorsFromConfig = (config: VisualsConfig) => {
     const { primaryCustomColor, secondaryCustomColor, tertiaryCustomColor } = config;
     cursorStyles.Custom = [primaryCustomColor, secondaryCustomColor, tertiaryCustomColor].map(
-        (color) => '#' + tinycolor.fromRatio(color).toHex()
+        (color) => tinycolor.fromRatio(color).toHex8String()
     ) as CursorStyle;
 };
 


### PR DESCRIPTION
## Summary

Correctly sets alpha values when loading cursor configs in the web UI.

Fixes [TF-1159](https://ultrahaptics.atlassian.net/browse/TF-1159).


### Tests Added

Added [TF-T448](https://ultrahaptics.atlassian.net/projects/TF?selectedItem=com.atlassian.plugins.atlassian-connect-plugin:com.kanoah.test-manager__main-project-page#!/testCase/TF-T448) to test this issue in future.


## Contributor Tasks

_These tasks are for the pull request creator to tick off._

- [ ] PO review (optional depending on work type)
- [ ] XDR review (optional depending on work type)
- [ ] QA review (or another developer if no QA is available)
- [ ] Ensure documentation requirements are met e.g., public API is commented
- [ ] Relevant changelogs have been updated with user-visible changes
    - [ ] [TouchFree Windows](/ultraleap/touchfree/blob/-/CHANGELOG-windows.md)
    - [ ] [TouchFree BrightSign](/ultraleap/touchfree/blob/-/CHANGELOG-brightsign.md)
    - [ ] [TouchFree Web Tooling](/ultraleap/touchfree/blob/-/TF_Tooling_Web/CHANGELOG.md)
- [ ] Consider any licensing/other legal implications e.g., notices required

If there is an associated JIRA issue:
- [x] Include a link to the JIRA issue in the summary above
- [ ] Make sure the fix version on the issue is set correctly

## Reviewer Tasks

_Add any instructions or tasks for the reviewer such as specific test considerations before this can be merged._

- [x] Developer testing
- [x] Code reviewed
- [ ] Non-code assets reviewed
- [ ] Documentation reviewed - includes checking documentation requirements are met and not missing e.g., public API is commented


[TF-1159]: https://ultrahaptics.atlassian.net/browse/TF-1159?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ