### PR TITLE
Don't consider black as transparent in overlay

### DIFF
--- a/CHANGELOG-windows.md
+++ b/CHANGELOG-windows.md
@@ -41,6 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Unity Settings: Cursor config correctly reloads when modified on disk
 - Service: Fixed an issue where the TouchFree Service would frequently throw exceptions when a client disconnects
 - Overlay Application: Fixed an issue where modified cursor alpha values would not be updated correctly
+- Overlay Application: Fixed an issue where black cursors would render transparent on some systems
 
 
 ## [2.4.0] - 2022-10-14

--- a/TF_Application/Assets/TouchFree_Application/Scripts/TransparentWindow.cs
+++ b/TF_Application/Assets/TouchFree_Application/Scripts/TransparentWindow.cs
@@ -25,9 +25,6 @@ namespace Ultraleap.TouchFree
         [DllImport("user32.dll")]
         private static extern uint GetWindowLong(IntPtr hWnd, int nIndex);
 
-        [DllImport("user32.dll", EntryPoint = "SetLayeredWindowAttributes")]
-        static extern int SetLayeredWindowAttributes(IntPtr hwnd, int crKey, byte bAlpha, int dwFlags);
-
         [DllImport("user32.dll", EntryPoint = "SetWindowPos")]
         private static extern int SetWindowPos(IntPtr hwnd, int hwndInsertAfter, int x, int y, int cx, int cy, int uFlags);
 

--- a/TF_Application/Assets/TouchFree_Application/Scripts/TransparentWindow.cs
+++ b/TF_Application/Assets/TouchFree_Application/Scripts/TransparentWindow.cs
@@ -62,7 +62,6 @@ namespace Ultraleap.TouchFree
         {
 #if !UNITY_EDITOR // You really don't want to enable this in the editor..
             hwnd = FindWindow(null, "TouchFree");
-            //SetLayeredWindowAttributes(hwnd, 0, 255, LWA_ALPHA);// Transparency=51=20%
             SetWindowLong(hwnd, GWL_STYLE, WS_POPUP | WS_VISIBLE);
 #endif
 

--- a/TF_Application/Assets/TouchFree_Application/Scripts/TransparentWindow.cs
+++ b/TF_Application/Assets/TouchFree_Application/Scripts/TransparentWindow.cs
@@ -62,7 +62,7 @@ namespace Ultraleap.TouchFree
         {
 #if !UNITY_EDITOR // You really don't want to enable this in the editor..
             hwnd = FindWindow(null, "TouchFree");
-            SetLayeredWindowAttributes(hwnd, 0, 255, LWA_ALPHA);// Transparency=51=20%
+            //SetLayeredWindowAttributes(hwnd, 0, 255, LWA_ALPHA);// Transparency=51=20%
             SetWindowLong(hwnd, GWL_STYLE, WS_POPUP | WS_VISIBLE);
 #endif
 


### PR DESCRIPTION
## Summary

Fixes [TF-1138](https://ultrahaptics.atlassian.net/browse/TF-1138), where some systems would interpret black to be a transparent colour, resulting in black cursors rendering transparent.

Camera clear colour is set to 0 alpha in Unity already, which removes the need for the `SetLayeredWindowAttributes` call which was introducing this problem on certain systems.

### Tests Added

Added [TF-T450 (1.0)](https://ultrahaptics.atlassian.net/projects/TF?selectedItem=com.atlassian.plugins.atlassian-connect-plugin:com.kanoah.test-manager__main-project-page#!/testCase/TF-T450) to test this issue in future.

## Contributor Tasks

_These tasks are for the pull request creator to tick off._

- [ ] PO review (optional depending on work type)
- [ ] XDR review (optional depending on work type)
- [ ] QA review (or another developer if no QA is available)
- [ ] Ensure documentation requirements are met e.g., public API is commented
- [x] Relevant changelogs have been updated with user-visible changes
    - [x] [TouchFree Windows](/ultraleap/touchfree/blob/-/CHANGELOG-windows.md)
    - [ ] [TouchFree BrightSign](/ultraleap/touchfree/blob/-/CHANGELOG-brightsign.md)
    - [ ] [TouchFree Web Tooling](/ultraleap/touchfree/blob/-/TF_Tooling_Web/CHANGELOG.md)
- [ ] Consider any licensing/other legal implications e.g., notices required

If there is an associated JIRA issue:
- [x] Include a link to the JIRA issue in the summary above
- [ ] Make sure the fix version on the issue is set correctly

## Reviewer Tasks

_Add any instructions or tasks for the reviewer such as specific test considerations before this can be merged._

- [ ] Developer testing
- [ ] Code reviewed
- [ ] Non-code assets reviewed
- [ ] Documentation reviewed - includes checking documentation requirements are met and not missing e.g., public API is commented


[TF-1138]: https://ultrahaptics.atlassian.net/browse/TF-1138?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ