### PR TITLE
Remove double connection on connection manager init

### DIFF
--- a/TF_Tooling_Web/src/Connection/ConnectionManager.ts
+++ b/TF_Tooling_Web/src/Connection/ConnectionManager.ts
@@ -70,12 +70,11 @@ export class ConnectionManager extends EventTarget {
     // Used to begin the connection. Creates the required <MessageReceiver>.
     // Also attempts to immediately <Connect> to a WebSocket.
     public static init(initParams?: InitParams) {
+        ConnectionManager.messageReceiver = new MessageReceiver();
+        ConnectionManager.instance = new ConnectionManager();
         if (initParams?.address) {
             ConnectionManager.SetAddress(initParams.address);
         }
-        ConnectionManager.messageReceiver = new MessageReceiver();
-        ConnectionManager.instance = new ConnectionManager();
-        ConnectionManager.Connect();
     }
 
     // Function: AddConnectionListener

--- a/TF_Tooling_Web/src/Connection/ConnectionManager.ts
+++ b/TF_Tooling_Web/src/Connection/ConnectionManager.ts
@@ -74,6 +74,8 @@ export class ConnectionManager extends EventTarget {
         ConnectionManager.instance = new ConnectionManager();
         if (initParams?.address) {
             ConnectionManager.SetAddress(initParams.address);
+        } else {
+            ConnectionManager.Connect();
         }
     }
 


### PR DESCRIPTION
## Summary

The last change to `ConnectionManager` mistakenly added a double connection to the service on init. This fixes that.

## Contributor Tasks

_These tasks are for the pull request creator to tick off._

- [ ] Relevant changelogs have been updated with user-visible changes
    - [ ] [TouchFree Windows](/ultraleap/touchfree/blob/-/CHANGELOG-windows.md)
    - [ ] [TouchFree BrightSign](/ultraleap/touchfree/blob/-/CHANGELOG-brightsign.md)
    - [ ] [TouchFree Web Tooling](/ultraleap/touchfree/blob/-/TF_Tooling_Web/CHANGELOG.md)

## Reviewer Tasks

_Add any instructions or tasks for the reviewer such as specific test considerations before this can be merged._

- [ ] Developer testing
- [x] Code reviewed
- [ ] Non-code assets reviewed
- [ ] Documentation reviewed - includes checking documentation requirements are met and not missing e.g., public API is commented