### PR TITLE
[TF-1101, TF-690] Update manual setup to use `window.innerX`

### DIFF
--- a/TF_Settings_Web/src/Pages/Camera/ManualSetup/ManualSetupScreen.tsx
+++ b/TF_Settings_Web/src/Pages/Camera/ManualSetup/ManualSetupScreen.tsx
@@ -60,8 +60,8 @@ const reducer = (state: PhysicalState, content: Partial<PhysicalState>) => {
         },
         ScreenHeightM: newState.screenHeight / 100,
         ScreenRotationD: newState.screenTilt,
-        ScreenHeightPX: window.screen.height * window.devicePixelRatio,
-        ScreenWidthPX: window.screen.width * window.devicePixelRatio,
+        ScreenHeightPX: window.innerHeight,
+        ScreenWidthPX: window.innerWidth,
     };
     ConfigurationManager.RequestConfigFileChange(null, config, (result) => {
         if (result.status !== 'Success') {


### PR DESCRIPTION
## Summary

Change manual setup screen to use `window.innerX` rather than `window.screen.x * window.devicePixelRatio` for TouchFree's pixel screen size.

Closes [TF-1101](https://ultrahaptics.atlassian.net/browse/TF-1102) and [TF-690](https://ultrahaptics.atlassian.net/browse/TF-690).

## Contributor Tasks

_These tasks are for the pull request creator to tick off._

- [ ] ~Relevant changelogs have been updated with user-visible changes~
    - [ ] ~[TouchFree Windows](/ultraleap/touchfree/blob/-/CHANGELOG-windows.md)~
    - [ ] ~[TouchFree BrightSign](/ultraleap/touchfree/blob/-/CHANGELOG-brightsign.md)~
    - [ ] ~[TouchFree Web Tooling](/ultraleap/touchfree/blob/-/TF_Tooling_Web/CHANGELOG.md)~

## Reviewer Tasks

1. Open web settings
2. Go to manual setup screen
3. Open dev tools and go to network tab
4. Find `connect` and message with action "SET_CONFIGURATION_FILE"
5. Inside content > physical, `ScreenHeightPX` and `ScreenWidthPX` should be integer values regardless of OS resolution scaling or browser zoom.

- [x] Developer testing
- [x] Code reviewed
- [ ] Non-code assets reviewed
- [ ] Documentation reviewed - includes checking documentation requirements are met and not missing e.g., public API is commented

[TF-1101]: https://ultrahaptics.atlassian.net/browse/TF-1101?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TF-690]: https://ultrahaptics.atlassian.net/browse/TF-690?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ