### PR TITLE
[TF-696] Round manual web configs to 2 places

### DIFF
--- a/TF_Settings_Web/src/Components/TextEntry/TextEntry.tsx
+++ b/TF_Settings_Web/src/Components/TextEntry/TextEntry.tsx
@@ -1,7 +1,7 @@
 import styles from './TextEntry.module.scss';
 
 import classnames from 'classnames/bind';
-import React, { ChangeEventHandler, MouseEventHandler, PointerEventHandler } from 'react';
+import React, { ChangeEventHandler, MouseEventHandler, FocusEventHandler, PointerEventHandler } from 'react';
 
 const classes = classnames.bind(styles);
 
@@ -12,14 +12,16 @@ interface TextEntryProps {
     onChange: ChangeEventHandler<HTMLInputElement>;
     onPointerDown: PointerEventHandler<HTMLElement>;
     onClick?: MouseEventHandler<HTMLElement>;
+    onBlur: FocusEventHandler<HTMLElement>;
 }
 
-const TextEntry: React.FC<TextEntryProps> = ({ name, value, selected, onChange, onClick, onPointerDown }) => {
+const TextEntry: React.FC<TextEntryProps> = ({ name, value, selected, onChange, onClick, onPointerDown, onBlur }) => {
     return (
         <label
             onClick={onClick}
             onPointerDown={onPointerDown}
             className={classes('background-label', { 'background-label--selected': selected })}
+            onBlur={onBlur}
         >
             <p className={classes('label')}>{name}</p>
             <label className={classes('container')}>

--- a/TF_Settings_Web/src/Pages/Camera/ManualSetup/ManualSetupScreen.tsx
+++ b/TF_Settings_Web/src/Pages/Camera/ManualSetup/ManualSetupScreen.tsx
@@ -87,20 +87,21 @@ const ManualSetupScreen = () => {
                 ? -config.physical.LeapRotationD.X - config.physical.LeapRotationD.Z
                 : config.physical.LeapRotationD.X;
         cameraRotation = cameraRotation <= -180 ? cameraRotation + 360 : cameraRotation;
+        cameraRotation = roundToTwoDecimals(cameraRotation);
 
         dispatch({
-            screenHeight: roundToFiveDecimals(config.physical.ScreenHeightM * 100),
-            cameraHeight: roundToFiveDecimals(config.physical.LeapPositionRelativeToScreenBottomM.Y * 100),
-            cameraLeftToRight: roundToFiveDecimals(config.physical.LeapPositionRelativeToScreenBottomM.X * 100),
-            cameraDistanceFromScreen: roundToFiveDecimals(-config.physical.LeapPositionRelativeToScreenBottomM.Z * 100),
+            screenHeight: roundToTwoDecimals(config.physical.ScreenHeightM * 100),
+            cameraHeight: roundToTwoDecimals(config.physical.LeapPositionRelativeToScreenBottomM.Y * 100),
+            cameraLeftToRight: roundToTwoDecimals(config.physical.LeapPositionRelativeToScreenBottomM.X * 100),
+            cameraDistanceFromScreen: roundToTwoDecimals(-config.physical.LeapPositionRelativeToScreenBottomM.Z * 100),
             cameraRotation,
             physicalConfig: config.physical,
             screenTilt: config.physical.ScreenRotationD,
         });
     };
 
-    const roundToFiveDecimals = (numberIn: number) => {
-        return Math.round(numberIn * 100000) / 100000;
+    const roundToTwoDecimals = (numberIn: number) => {
+        return Math.round(numberIn * 100) / 100;
     };
 
     const update = (key: keyof PhysicalState, event: FormEvent<HTMLInputElement>) => {

--- a/TF_Settings_Web/src/Pages/Camera/ManualSetup/ManualSetupScreen.tsx
+++ b/TF_Settings_Web/src/Pages/Camera/ManualSetup/ManualSetupScreen.tsx
@@ -1,7 +1,7 @@
 import styles from './ManualSetup.module.scss';
 
 import classnames from 'classnames/bind';
-import { FormEvent, useEffect, useReducer } from 'react';
+import { FormEvent, FocusEvent, useEffect, useReducer } from 'react';
 
 import { useIsLandscape } from '@/customHooks';
 
@@ -105,7 +105,13 @@ const ManualSetupScreen = () => {
     };
 
     const update = (key: keyof PhysicalState, event: FormEvent<HTMLInputElement>) => {
-        dispatch({ [key]: parseFloat((event.currentTarget?.value == '') ? '0' : event.currentTarget?.value) });
+        dispatch({ [key]: event.currentTarget?.value });
+    };
+
+    const unfocus = (key: keyof PhysicalState, event: FocusEvent<HTMLElement, Element>) => {
+        const val = event.target.getAttribute('value');
+        const num = val == null ? 0 : parseFloat(val);
+        dispatch({ [key]: roundToTwoDecimals(parseFloat(val == null || isNaN(num) ? '0' : val)) });
     };
 
     return (
@@ -125,6 +131,7 @@ const ManualSetupScreen = () => {
                             value={state.screenHeight.toString()}
                             onChange={(e) => update('screenHeight', e)}
                             onPointerDown={() => dispatch({ selectedView: 'screenHeight' })}
+                            onBlur={(e) => unfocus('screenHeight', e)}
                             selected={state.selectedView === 'screenHeight'}
                         />
                         <TextEntry
@@ -132,6 +139,7 @@ const ManualSetupScreen = () => {
                             value={state.cameraHeight.toString()}
                             onChange={(e) => update('cameraHeight', e)}
                             onPointerDown={() => dispatch({ selectedView: 'cameraHeight' })}
+                            onBlur={(e) => unfocus('cameraHeight', e)}
                             selected={state.selectedView === 'cameraHeight'}
                         />
                         <TextEntry
@@ -139,6 +147,7 @@ const ManualSetupScreen = () => {
                             value={state.cameraLeftToRight.toString()}
                             onChange={(e) => update('cameraLeftToRight', e)}
                             onPointerDown={() => dispatch({ selectedView: 'cameraLeftToRight' })}
+                            onBlur={(e) => unfocus('cameraLeftToRight', e)}
                             selected={state.selectedView === 'cameraLeftToRight'}
                         />
                     </div>
@@ -148,6 +157,7 @@ const ManualSetupScreen = () => {
                             value={state.screenTilt.toString()}
                             onChange={(e) => update('screenTilt', e)}
                             onPointerDown={() => dispatch({ selectedView: 'screenTilt' })}
+                            onBlur={(e) => unfocus('screenTilt', e)}
                             selected={state.selectedView === 'screenTilt'}
                         />
                         <TextEntry
@@ -155,6 +165,7 @@ const ManualSetupScreen = () => {
                             value={state.cameraRotation.toString()}
                             onChange={(e) => update('cameraRotation', e)}
                             onPointerDown={() => dispatch({ selectedView: 'cameraRotation' })}
+                            onBlur={(e) => unfocus('cameraRotation', e)}
                             selected={state.selectedView === 'cameraRotation'}
                         />
                         <TextEntry
@@ -162,6 +173,7 @@ const ManualSetupScreen = () => {
                             value={state.cameraDistanceFromScreen.toString()}
                             onChange={(e) => update('cameraDistanceFromScreen', e)}
                             onPointerDown={() => dispatch({ selectedView: 'cameraDistanceFromScreen' })}
+                            onBlur={(e) => unfocus('cameraDistanceFromScreen', e)}
                             selected={state.selectedView === 'cameraDistanceFromScreen'}
                         />
                     </div>


### PR DESCRIPTION
## Summary

Rounds all calibration values to 2 decimal places instead of 5 in the manual configuration screen.

https://ultrahaptics.atlassian.net/browse/TF-696


### Tests Added

Tests already say "to two decimal places", so they have not been edited in this MR 😅

## Contributor Tasks

_These tasks are for the pull request creator to tick off._

- [ ] PO review (optional depending on work type)
- [ ] XDR review (optional depending on work type)
- [ ] QA review (or another developer if no QA is available)
- [ ] Ensure documentation requirements are met e.g., public API is commented
- [ ] Relevant changelogs have been updated with user-visible changes
    - [ ] [TouchFree Windows](/ultraleap/touchfree/blob/-/CHANGELOG-windows.md)
    - [ ] [TouchFree BrightSign](/ultraleap/touchfree/blob/-/CHANGELOG-brightsign.md)
    - [ ] [TouchFree Web Tooling](/ultraleap/touchfree/blob/-/TF_Tooling_Web/CHANGELOG.md)
- [ ] Consider any licensing/other legal implications e.g., notices required

If there is an associated JIRA issue:
- [ ] Include a link to the JIRA issue in the summary above
- [ ] Make sure the fix version on the issue is set correctly

## Reviewer Tasks

_Add any instructions or tasks for the reviewer such as specific test considerations before this can be merged._

- [ ] Developer testing
- [ ] Code reviewed
- [ ] Non-code assets reviewed
- [ ] Documentation reviewed - includes checking documentation requirements are met and not missing e.g., public API is commented
