### PR TITLE
[TF-536] Fixed z-ordering of cursor in masking screen

### DIFF
--- a/CHANGELOG-windows.md
+++ b/CHANGELOG-windows.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Unity Settings/Service: Fixed an issue where clicking was very difficult while Touch Plane and Scroll and Drag were both active
 - Unity Settings: Fixed an issue with moving the bottom masking slider
 - Unity Settings: Cursor config correctly reloads when modified on disk
+- Unity Settings: Fixed render order of cursor/camera in masking screen
 - Service: Fixed an issue where the TouchFree Service would frequently throw exceptions when a client disconnects
 - Overlay Application: Fixed an issue where modified cursor alpha values would not be updated correctly
 - Service: Fixed an issue where the TouchFree Service would crash when non-integer configuration value was sent for an integer configuration property e.g. screen width.

--- a/TF_Settings_and_Tooling_Unity/Assets/TouchFree/SettingsUI/Prefabs/Camera Previews.prefab
+++ b/TF_Settings_and_Tooling_Unity/Assets/TouchFree/SettingsUI/Prefabs/Camera Previews.prefab
@@ -2566,7 +2566,7 @@ RectTransform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7082437387604401660}
   m_LocalRotation: {x: 0, y: 0, z: 1, w: 0}
-  m_LocalPosition: {x: 0, y: 0, z: -1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:


### PR DESCRIPTION
## Summary

Fixes a minor bug where the cursor ring would not render over the masked image preview in Unity settings.

https://ultrahaptics.atlassian.net/browse/TF-536


### Tests Added

Added step 9 to [TF-T394 (1.0)](https://ultrahaptics.atlassian.net/projects/TF?selectedItem=com.atlassian.plugins.atlassian-connect-plugin:com.kanoah.test-manager__main-project-page#!/testCase/TF-T394).


## Contributor Tasks

_These tasks are for the pull request creator to tick off._

- [ ] PO review (optional depending on work type)
- [ ] XDR review (optional depending on work type)
- [ ] QA review (or another developer if no QA is available)
- [ ] Ensure documentation requirements are met e.g., public API is commented
- [x] Relevant changelogs have been updated with user-visible changes
    - [x] [TouchFree Windows](/ultraleap/touchfree/blob/-/CHANGELOG-windows.md)
    - [ ] [TouchFree BrightSign](/ultraleap/touchfree/blob/-/CHANGELOG-brightsign.md)
    - [ ] [TouchFree Web Tooling](/ultraleap/touchfree/blob/-/TF_Tooling_Web/CHANGELOG.md)
- [ ] Consider any licensing/other legal implications e.g., notices required

If there is an associated JIRA issue:
- [ ] Include a link to the JIRA issue in the summary above
- [ ] Make sure the fix version on the issue is set correctly

## Reviewer Tasks

_Add any instructions or tasks for the reviewer such as specific test considerations before this can be merged._

- [x] Developer testing
- [x] Code reviewed
- [ ] Non-code assets reviewed
- [ ] Documentation reviewed - includes checking documentation requirements are met and not missing e.g., public API is commented
