### PR TITLE
[TF-479] Correctly set CTI path on load in Unity

### DIFF
--- a/CHANGELOG-windows.md
+++ b/CHANGELOG-windows.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Unity Settings/Service: Fixed an issue where using Touch Plane with Scroll and Drag caused cursor jumps
 - Unity Settings/Service: Fixed an issue where clicking was very difficult while Touch Plane and Scroll and Drag were both active
+- Unity Settings: CTI path now correctly sets on load
 - Unity Settings: Fixed an issue with moving the bottom masking slider
 - Unity Settings: Cursor config correctly reloads when modified on disk
 - Service: Fixed an issue where the TouchFree Service would frequently throw exceptions when a client disconnects

--- a/TF_Settings_and_Tooling_Unity/Assets/TouchFree/SettingsUI/Scripts/Configuration/ConfigUI/TFAppConfigUI.cs
+++ b/TF_Settings_and_Tooling_Unity/Assets/TouchFree/SettingsUI/Scripts/Configuration/ConfigUI/TFAppConfigUI.cs
@@ -342,6 +342,7 @@ namespace Ultraleap.TouchFree.ServiceUI
             // CTI settings
             EnableCTIToggle.SetIsOnWithoutNotify(TFAppConfig.Config.ctiEnabled);
             CTIFilePath = TFAppConfig.Config.ctiFilePath;
+            CurrentCTIFilepath.SetTextWithoutNotify(CTIFilePath);
             CTIShowDelayField.SetTextWithoutNotify(TFAppConfig.Config.ctiShowAfterTimer.ToString());
 
             ShowHideCursorControls(TFAppConfig.Config.cursorEnabled);


### PR DESCRIPTION
## Summary

Fixes an issue where the path to the CTI file would not be set on load in the Unity settings.

https://ultrahaptics.atlassian.net/browse/TF-479


### Tests Added

Added step 9 to [TF-T365 (1.0)](https://ultrahaptics.atlassian.net/projects/TF?selectedItem=com.atlassian.plugins.atlassian-connect-plugin:com.kanoah.test-manager__main-project-page#!/testCase/TF-T365).


## Contributor Tasks

_These tasks are for the pull request creator to tick off._

- [ ] PO review (optional depending on work type)
- [ ] XDR review (optional depending on work type)
- [ ] QA review (or another developer if no QA is available)
- [ ] Ensure documentation requirements are met e.g., public API is commented
- [x] Relevant changelogs have been updated with user-visible changes
    - [x] [TouchFree Windows](/ultraleap/touchfree/blob/-/CHANGELOG-windows.md)
    - [ ] [TouchFree BrightSign](/ultraleap/touchfree/blob/-/CHANGELOG-brightsign.md)
    - [ ] [TouchFree Web Tooling](/ultraleap/touchfree/blob/-/TF_Tooling_Web/CHANGELOG.md)
- [ ] Consider any licensing/other legal implications e.g., notices required

If there is an associated JIRA issue:
- [ ] Include a link to the JIRA issue in the summary above
- [ ] Make sure the fix version on the issue is set correctly

## Reviewer Tasks

_Add any instructions or tasks for the reviewer such as specific test considerations before this can be merged._

- [x] Developer testing
- [x] Code reviewed
- [ ] Non-code assets reviewed
- [ ] Documentation reviewed - includes checking documentation requirements are met and not missing e.g., public API is commented
