### PR TITLE
[TF-1178] Fix long CTI paths in web UI

### DIFF
--- a/TF_Settings_Web/src/TauriUtils.ts
+++ b/TF_Settings_Web/src/TauriUtils.ts
@@ -34,7 +34,9 @@ export const readVisualsConfig = async (): Promise<VisualsConfig> => {
     const rawConfig: string = await invoke('read_file_to_string', {
         path: 'C:/ProgramData/Ultraleap/TouchFree/Configuration/TouchFreeConfig.json',
     });
-    return JSON.parse(rawConfig) as VisualsConfig;
+    const config = JSON.parse(rawConfig) as VisualsConfig;
+    config.ctiFilePath = config.ctiFilePath.replaceAll('\\', '/');
+    return config;
 };
 
 export const writeVisualsConfig = async (config: VisualsConfig) => {


### PR DESCRIPTION
## Summary

Fixes an issue where CTI paths could become very long in the web UI when the config had been applied from Unity settings, breaking the display.

https://ultrahaptics.atlassian.net/browse/TF-1178


### Tests Added

Don't think any tests are needed for this.


## Contributor Tasks

_These tasks are for the pull request creator to tick off._

- [ ] PO review (optional depending on work type)
- [ ] XDR review (optional depending on work type)
- [ ] QA review (or another developer if no QA is available)
- [ ] Ensure documentation requirements are met e.g., public API is commented
- [ ] Relevant changelogs have been updated with user-visible changes
    - [ ] [TouchFree Windows](/ultraleap/touchfree/blob/-/CHANGELOG-windows.md)
    - [ ] [TouchFree BrightSign](/ultraleap/touchfree/blob/-/CHANGELOG-brightsign.md)
    - [ ] [TouchFree Web Tooling](/ultraleap/touchfree/blob/-/TF_Tooling_Web/CHANGELOG.md)
- [ ] Consider any licensing/other legal implications e.g., notices required

If there is an associated JIRA issue:
- [ ] Include a link to the JIRA issue in the summary above
- [ ] Make sure the fix version on the issue is set correctly

## Reviewer Tasks

_Add any instructions or tasks for the reviewer such as specific test considerations before this can be merged._

- [x] Developer testing
- [x] Code reviewed
- [ ] Non-code assets reviewed
- [ ] Documentation reviewed - includes checking documentation requirements are met and not missing e.g., public API is commented
