### PR TITLE
[TF-35] Allow custom IP and port for service

### DIFF
--- a/CHANGELOG-windows.md
+++ b/CHANGELOG-windows.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-
+- Unity Settings/Service/Overlay: Added ability to set custom IP and port
 - Service: `HandEntered` & `HandExited` events, sent when the active hand enters and exits the interaction zone (if enabled) respectively
 - Service: Removed informational level logging to improve readability of log files
 - Unity Settings: Added preset options for dark/light outline cursor

--- a/TF_Service_dotNet/TouchFree/Configuration/ServiceConfigFile.cs
+++ b/TF_Service_dotNet/TouchFree/Configuration/ServiceConfigFile.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using Ultraleap.TouchFree.Library.Connections;
+
+namespace Ultraleap.TouchFree.Library.Configuration
+{
+    public class ServiceConfigFile : ConfigFile<ServiceConfig, ServiceConfigFile>
+    {
+        protected override string _ConfigFileName => "ServiceConfig.json";
+    }
+
+    [Serializable]
+    public record class ServiceConfig
+    {
+        public string ServiceIP = "127.0.0.1";
+        public string ServicePort = "9739";
+    }
+}

--- a/TF_Service_dotNet/TouchFree/Configuration/TrackingConfigFile.cs
+++ b/TF_Service_dotNet/TouchFree/Configuration/TrackingConfigFile.cs
@@ -15,8 +15,6 @@ namespace Ultraleap.TouchFree.Library.Configuration
         public bool AllowImages = true;
         public bool CameraReversed = false;
         public bool AnalyticsEnabled = true;
-        public string ServiceIP = "127.0.0.1";
-        public string ServicePort = "9739";
     }
 
     [Serializable]

--- a/TF_Service_dotNet/TouchFree/Configuration/TrackingConfigFile.cs
+++ b/TF_Service_dotNet/TouchFree/Configuration/TrackingConfigFile.cs
@@ -15,7 +15,7 @@ namespace Ultraleap.TouchFree.Library.Configuration
         public bool AllowImages = true;
         public bool CameraReversed = false;
         public bool AnalyticsEnabled = true;
-        public string ServiceIP = "localhost";
+        public string ServiceIP = "127.0.0.1";
         public string ServicePort = "9739";
     }
 

--- a/TF_Service_dotNet/TouchFree/Configuration/TrackingConfigFile.cs
+++ b/TF_Service_dotNet/TouchFree/Configuration/TrackingConfigFile.cs
@@ -15,6 +15,8 @@ namespace Ultraleap.TouchFree.Library.Configuration
         public bool AllowImages = true;
         public bool CameraReversed = false;
         public bool AnalyticsEnabled = true;
+        public string ServiceIP = "localhost";
+        public string ServicePort = "9739";
     }
 
     [Serializable]

--- a/TF_Service_dotNet/TouchFree_Service/Program.cs
+++ b/TF_Service_dotNet/TouchFree_Service/Program.cs
@@ -7,7 +7,7 @@ namespace Ultraleap.TouchFree.Service
 {
     public class Program
     {
-        private static TrackingConfig config = null;
+        private static ServiceConfig config = null;
 
         static void Main(string[] args)
         {
@@ -18,7 +18,7 @@ namespace Ultraleap.TouchFree.Service
             TouchFreeLog.WriteLine($"TouchFree Version: v{VersionManager.Version}");
             TouchFreeLog.WriteLine();
 
-            config = TrackingConfigFile.LoadConfig();
+            config = ServiceConfigFile.LoadConfig();
 
             TouchFreeLog.WriteLine("TouchFree IP: http://" + config.ServiceIP + ":" + config.ServicePort);
             TouchFreeLog.WriteLine();

--- a/TF_Service_dotNet/TouchFree_Service/Program.cs
+++ b/TF_Service_dotNet/TouchFree_Service/Program.cs
@@ -1,12 +1,18 @@
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using System.IO;
+using System;
 using Ultraleap.TouchFree.Library.Configuration;
+using Newtonsoft.Json.Linq;
 
 namespace Ultraleap.TouchFree.Service
 {
     public class Program
     {
+        private static string serviceIP = "localhost";
+        private static string servicePort = "9739";
+
         static void Main(string[] args)
         {
 #if !DEBUG
@@ -14,6 +20,17 @@ namespace Ultraleap.TouchFree.Service
 #endif
 
             TouchFreeLog.WriteLine($"TouchFree Version: v{VersionManager.Version}");
+            TouchFreeLog.WriteLine();
+
+            string pathToConfig = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), "Ultraleap\\TouchFree\\Configuration\\TrackingConfig.json");
+            if (File.Exists(pathToConfig))
+            {
+                JObject obj = JObject.Parse(File.ReadAllText(pathToConfig));
+                if (obj.ContainsKey("ServiceIP")) serviceIP = obj["ServiceIP"].ToString();
+                if (obj.ContainsKey("ServicePort")) servicePort = obj["ServicePort"].ToString();
+            }
+
+            TouchFreeLog.WriteLine("TouchFree IP: http://" + serviceIP + ":" + servicePort);
             TouchFreeLog.WriteLine();
 
             CreateHostBuilder(args).Build().Run();
@@ -24,7 +41,7 @@ namespace Ultraleap.TouchFree.Service
                 .ConfigureWebHostDefaults(webBuilder =>
                 {
                     webBuilder.UseStartup<Startup>();
-                    webBuilder.UseUrls("http://localhost:9739");
+                    webBuilder.UseUrls("http://" + serviceIP + ":" + servicePort);
 #if !DEBUG
                     webBuilder.ConfigureLogging((loggingBuilder) => loggingBuilder.SetMinimumLevel(LogLevel.Warning));
 #endif

--- a/TF_Service_dotNet/TouchFree_Service/Program.cs
+++ b/TF_Service_dotNet/TouchFree_Service/Program.cs
@@ -20,7 +20,7 @@ namespace Ultraleap.TouchFree.Service
 
             config = ServiceConfigFile.LoadConfig();
 
-            TouchFreeLog.WriteLine("TouchFree IP: http://" + config.ServiceIP + ":" + config.ServicePort);
+            TouchFreeLog.WriteLine($"TouchFree IP: http://{config.ServiceIP}:{config.ServicePort}");
             TouchFreeLog.WriteLine();
 
             CreateHostBuilder(args).Build().Run();
@@ -31,7 +31,7 @@ namespace Ultraleap.TouchFree.Service
                 .ConfigureWebHostDefaults(webBuilder =>
                 {
                     webBuilder.UseStartup<Startup>();
-                    webBuilder.UseUrls("http://" + config.ServiceIP + ":" + config.ServicePort);
+                    webBuilder.UseUrls($"http://{config.ServiceIP}:{config.ServicePort}");
 #if !DEBUG
                     webBuilder.ConfigureLogging((loggingBuilder) => loggingBuilder.SetMinimumLevel(LogLevel.Warning));
 #endif

--- a/TF_Service_dotNet/TouchFree_Service/Program.cs
+++ b/TF_Service_dotNet/TouchFree_Service/Program.cs
@@ -1,17 +1,13 @@
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
-using System.IO;
-using System;
 using Ultraleap.TouchFree.Library.Configuration;
-using Newtonsoft.Json.Linq;
 
 namespace Ultraleap.TouchFree.Service
 {
     public class Program
     {
-        private static string serviceIP = "localhost";
-        private static string servicePort = "9739";
+        private static TrackingConfig config = null;
 
         static void Main(string[] args)
         {
@@ -22,15 +18,9 @@ namespace Ultraleap.TouchFree.Service
             TouchFreeLog.WriteLine($"TouchFree Version: v{VersionManager.Version}");
             TouchFreeLog.WriteLine();
 
-            string pathToConfig = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), "Ultraleap\\TouchFree\\Configuration\\TrackingConfig.json");
-            if (File.Exists(pathToConfig))
-            {
-                JObject obj = JObject.Parse(File.ReadAllText(pathToConfig));
-                if (obj.ContainsKey("ServiceIP")) serviceIP = obj["ServiceIP"].ToString();
-                if (obj.ContainsKey("ServicePort")) servicePort = obj["ServicePort"].ToString();
-            }
+            config = TrackingConfigFile.LoadConfig();
 
-            TouchFreeLog.WriteLine("TouchFree IP: http://" + serviceIP + ":" + servicePort);
+            TouchFreeLog.WriteLine("TouchFree IP: http://" + config.ServiceIP + ":" + config.ServicePort);
             TouchFreeLog.WriteLine();
 
             CreateHostBuilder(args).Build().Run();
@@ -41,7 +31,7 @@ namespace Ultraleap.TouchFree.Service
                 .ConfigureWebHostDefaults(webBuilder =>
                 {
                     webBuilder.UseStartup<Startup>();
-                    webBuilder.UseUrls("http://" + serviceIP + ":" + servicePort);
+                    webBuilder.UseUrls("http://" + config.ServiceIP + ":" + config.ServicePort);
 #if !DEBUG
                     webBuilder.ConfigureLogging((loggingBuilder) => loggingBuilder.SetMinimumLevel(LogLevel.Warning));
 #endif

--- a/TF_Settings_and_Tooling_Unity/Assets/TouchFree/Tooling/Scripts/Connection/ConnectionManager.cs
+++ b/TF_Settings_and_Tooling_Unity/Assets/TouchFree/Tooling/Scripts/Connection/ConnectionManager.cs
@@ -81,10 +81,10 @@ namespace Ultraleap.TouchFree.Tooling.Connection
         {
             shouldReconnect = true;
 
-            //Read IP and port from TrackingConfig before we attempt to connect
+            //Read IP and port from config before we attempt to connect
             string ip = "127.0.0.1";
             string port = "9739";
-            string configPath = ConfigFileUtils.ConfigFileDirectory + "TrackingConfig.json";
+            string configPath = ConfigFileUtils.ConfigFileDirectory + "ServiceConfig.json";
             if (File.Exists(configPath))
             {
                 JObject obj = JObject.Parse(File.ReadAllText(configPath));

--- a/TF_Settings_and_Tooling_Unity/Assets/TouchFree/Tooling/Scripts/Connection/ConnectionManager.cs
+++ b/TF_Settings_and_Tooling_Unity/Assets/TouchFree/Tooling/Scripts/Connection/ConnectionManager.cs
@@ -1,8 +1,6 @@
 using Newtonsoft.Json.Linq;
 using System;
 using System.IO;
-using System.Web.Services.Description;
-using Ultraleap.TouchFree.ServiceShared;
 using UnityEngine;
 
 namespace Ultraleap.TouchFree.Tooling.Connection

--- a/TF_Settings_and_Tooling_Unity/Assets/TouchFree/Tooling/Scripts/Connection/ConnectionManager.cs
+++ b/TF_Settings_and_Tooling_Unity/Assets/TouchFree/Tooling/Scripts/Connection/ConnectionManager.cs
@@ -1,4 +1,8 @@
+using Newtonsoft.Json.Linq;
 using System;
+using System.IO;
+using System.Web.Services.Description;
+using Ultraleap.TouchFree.ServiceShared;
 using UnityEngine;
 
 namespace Ultraleap.TouchFree.Tooling.Connection
@@ -52,17 +56,6 @@ namespace Ultraleap.TouchFree.Tooling.Connection
         // An event allowing users to react to the active hand exiting the interaction zone.
         public static event Action HandExited;
 
-        // Variable: iPAddress
-        // The IP Address that will be used in the <ServiceConnection> to connect to the target WebSocket.
-        // This value is settable in the Inspector.
-        [Header("WebSocket connection values")]
-        [SerializeField] string iPAddress = "127.0.0.1";
-
-        // Variable: port
-        // The Port that will be used in the <ServiceConnection> to connect to the target WebSocket.
-        // This value is settable in the Inspector.
-        [SerializeField] string port = "9739";
-
         static bool shouldReconnect = false;
 
         // Group: Functions
@@ -87,7 +80,19 @@ namespace Ultraleap.TouchFree.Tooling.Connection
         {
             shouldReconnect = true;
 
-            currentServiceConnection = new ServiceConnection(iPAddress, port, RetryConnecting);
+            //Read IP and port from TrackingConfig before we attempt to connect
+            string ip = "127.0.0.1";
+            string port = "9739";
+            string configPath = ConfigFileUtils.ConfigFileDirectory + "TrackingConfig.json";
+            if (File.Exists(configPath))
+            {
+                JObject obj = JObject.Parse(File.ReadAllText(configPath));
+                if (obj.ContainsKey("ServiceIP")) ip = obj["ServiceIP"].ToString();
+                if (obj.ContainsKey("ServicePort")) port = obj["ServicePort"].ToString();
+            }
+            Debug.Log("Attempting to connect to TouchFree at: http://" + ip + ":" + port);
+
+            currentServiceConnection = new ServiceConnection(ip, port, RetryConnecting);
             if (currentServiceConnection.IsConnected())
             {
                 OnConnected?.Invoke();

--- a/TF_Settings_and_Tooling_Unity/Assets/TouchFree/Tooling/Scripts/Connection/ConnectionManager.cs
+++ b/TF_Settings_and_Tooling_Unity/Assets/TouchFree/Tooling/Scripts/Connection/ConnectionManager.cs
@@ -2,6 +2,9 @@ using Newtonsoft.Json.Linq;
 using System;
 using System.IO;
 using UnityEngine;
+#if SCREENCONTROL_CORE
+using Ultraleap.TouchFree.ServiceShared;
+#endif
 
 namespace Ultraleap.TouchFree.Tooling.Connection
 {

--- a/Testing/ServiceSocketTests/gulpfile.js
+++ b/Testing/ServiceSocketTests/gulpfile.js
@@ -57,7 +57,6 @@ gulp.task('startServer', function (callback) {
     var timerId = -1;
 
     function testWS() {
-		console.log("testWS");
         var ws = new WebSocket('ws://127.0.0.1:9739/connect');
 
         ws.onopen = function () {

--- a/Testing/ServiceSocketTests/gulpfile.js
+++ b/Testing/ServiceSocketTests/gulpfile.js
@@ -57,7 +57,8 @@ gulp.task('startServer', function (callback) {
     var timerId = -1;
 
     function testWS() {
-        var ws = new WebSocket('ws://localhost:9739/connect');
+		console.log("testWS");
+        var ws = new WebSocket('ws://127.0.0.1:9739/connect');
 
         ws.onopen = function () {
             console.log("Successfully connected to Server");


### PR DESCRIPTION
## Summary

Adds the ability to set `ServiceIP` and `ServicePort` in ServiceConfig.json which is then respected by the service & Unity applications and tooling.

https://ultrahaptics.atlassian.net/browse/TF-35


### Tests Added

Created test [TF-T454 (1.0)](https://ultrahaptics.atlassian.net/projects/TF?selectedItem=com.atlassian.plugins.atlassian-connect-plugin:com.kanoah.test-manager__main-project-page#!/testCase/TF-T454)


## Contributor Tasks

_These tasks are for the pull request creator to tick off._

- [ ] PO review (optional depending on work type)
- [ ] XDR review (optional depending on work type)
- [ ] QA review (or another developer if no QA is available)
- [x] Ensure documentation requirements are met e.g., public API is commented
- [x] Relevant changelogs have been updated with user-visible changes
    - [x] [TouchFree Windows](/ultraleap/touchfree/blob/-/CHANGELOG-windows.md)
    - [ ] [TouchFree BrightSign](/ultraleap/touchfree/blob/-/CHANGELOG-brightsign.md)
    - [ ] [TouchFree Web Tooling](/ultraleap/touchfree/blob/-/TF_Tooling_Web/CHANGELOG.md)
- [ ] Consider any licensing/other legal implications e.g., notices required

If there is an associated JIRA issue:
- [x] Include a link to the JIRA issue in the summary above
- [x] Make sure the fix version on the issue is set correctly

## Reviewer Tasks

_Add any instructions or tasks for the reviewer such as specific test considerations before this can be merged._

- [x] Developer testing
- [x] Code reviewed
- [ ] Non-code assets reviewed
- [x] Documentation reviewed - includes checking documentation requirements are met and not missing e.g., public API is commented
