### PR TITLE
Service: Improve messages when client and service API versions are di…

### DIFF
--- a/CHANGELOG-brightsign.md
+++ b/CHANGELOG-brightsign.md
@@ -31,6 +31,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Service: `HandEntered` & `HandExited` events, sent when the active hand enters and exits the interaction zone (if enabled) respectively
 - Service: Removed informational level logging to improve readability of log files
 
+### Changed
+
+- Service: Improved error and warning messaging when TouchFree Tooling and Service API versions do not match.
+
 ### Fixed
 
 - Service: Fixed an issue where the TouchFree Service would frequently throw exceptions when a client disconnects

--- a/CHANGELOG-windows.md
+++ b/CHANGELOG-windows.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Unity Settings: Allow resizing of window when in windowed mode
 - Unity Settings/Service/Overlay Application: Adjusted proportions of TouchFree icon
 - Unity Settings/Service: CTIs are now managed by the Service, not the Unity Settings
+- Service: Improved error and warning messaging when TouchFree Tooling and Service API versions do not match.
 
 ### Fixed
 - Unity Settings/Service: Fixed an issue where using Touch Plane with Scroll and Drag caused cursor jumps

--- a/TF_Service_dotNet/TouchFree/Connections/ConnectionTypes.cs
+++ b/TF_Service_dotNet/TouchFree/Connections/ConnectionTypes.cs
@@ -1,4 +1,6 @@
-﻿namespace Ultraleap.TouchFree.Library.Connections
+﻿using System;
+
+namespace Ultraleap.TouchFree.Library.Connections
 {
     public enum Compatibility
     {
@@ -8,6 +10,8 @@
         SERVICE_OUTDATED_WARNING,
         CLIENT_OUTDATED_WARNING
     }
+
+    public readonly record struct CompatibilityInformation(Compatibility Compatibility, Version ClientVersion, Version ServiceVersion);
 
     internal struct CommunicationWrapper<T>
     {

--- a/TF_Service_dotNet/TouchFreeTests/Connections/ClientConnectionTests.cs
+++ b/TF_Service_dotNet/TouchFreeTests/Connections/ClientConnectionTests.cs
@@ -25,7 +25,7 @@ namespace TouchFreeTests.Connections
             var result = ClientConnection.GetVersionCompability(clientVersion, parsedServiceVersion);
 
             // Assert
-            Assert.AreEqual(expectedCompatibility, result);
+            Assert.AreEqual(expectedCompatibility, result.Compatibility);
         }
     }
 }

--- a/TF_Tooling_Web/CHANGELOG.md
+++ b/TF_Tooling_Web/CHANGELOG.md
@@ -23,6 +23,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `SVGCursor.SetColor` allows you to set the color of the SVGCursor center fill, ring fill or center border.
 - `SVGCursor.ResetToDefaultColors` allows you reset the color of the entire SVGCursor back to it's default colors.
 
+### Changed
+
+- Improved error and warning messaging when TouchFree Tooling and Service API versions do not match.
+
 ### Deprecated
 
 - `ConnectionManager.AddConnectionListener()` - functions identically to the `WhenConnected` event added this release and has been deprecated in favor of it.

--- a/TF_Tooling_Web/src/Connection/MessageReceiver.ts
+++ b/TF_Tooling_Web/src/Connection/MessageReceiver.ts
@@ -162,7 +162,7 @@ export class MessageReceiver {
     CheckForHandshakeResponse(): void {
         const response: WebSocketResponse | undefined = this.handshakeQueue.shift();
 
-        if (response !== undefined) {
+        if (response) {
             const responseResult = MessageReceiver.HandleCallbackList(response, this.handshakeCallbacks);
 
             switch (responseResult) {
@@ -205,7 +205,7 @@ export class MessageReceiver {
     CheckForResponse(): void {
         const response: WebSocketResponse | undefined = this.responseQueue.shift();
 
-        if (response !== undefined) {
+        if (response) {
             const responseResult = MessageReceiver.HandleCallbackList(response, this.responseCallbacks);
 
             switch (responseResult) {
@@ -228,7 +228,7 @@ export class MessageReceiver {
     CheckForConfigState(): void {
         const configState: ConfigState | undefined = this.configStateQueue.shift();
 
-        if (configState !== undefined) {
+        if (configState) {
             const configResult = MessageReceiver.HandleCallbackList(configState, this.configStateCallbacks);
             switch (configResult) {
                 case 'NoCallbacksFound':
@@ -266,7 +266,7 @@ export class MessageReceiver {
     CheckForServiceStatus(): void {
         const serviceStatus: ServiceStatus | undefined = this.serviceStatusQueue.shift();
 
-        if (serviceStatus !== undefined) {
+        if (serviceStatus) {
             const callbackResult = MessageReceiver.HandleCallbackList(serviceStatus, this.serviceStatusCallbacks);
 
             switch (callbackResult) {
@@ -295,7 +295,7 @@ export class MessageReceiver {
     CheckForTrackingStateResponse(): void {
         const trackingStateResponse: TrackingStateResponse | undefined = this.trackingStateQueue.shift();
 
-        if (trackingStateResponse !== undefined) {
+        if (trackingStateResponse) {
             this.HandleTrackingStateResponse(trackingStateResponse);
         }
     }

--- a/TF_Tooling_Web/src/Connection/MessageReceiver.ts
+++ b/TF_Tooling_Web/src/Connection/MessageReceiver.ts
@@ -66,6 +66,15 @@ export class MessageReceiver {
     // that are awaiting response from the Service.
     responseCallbacks: { [id: string]: ResponseCallback } = {};
 
+    // Variable: handshakeQueue
+    // A queue of handshake <WebSocketResponses> that have been received from the Service.
+    handshakeQueue: Array<WebSocketResponse> = [];
+
+    // Variable: handshakeCallbacks
+    // A dictionary of unique request IDs and <ResponseCallbacks> that represent handshake requests
+    // that are awaiting response from the Service.
+    handshakeCallbacks: { [id: string]: ResponseCallback } = {};
+
     // Variable: configStateQueue
     // A queue of <ConfigState> that have been received from the Service.
     configStateQueue: Array<ConfigState> = [];
@@ -138,12 +147,56 @@ export class MessageReceiver {
     // Update function. Checks all queues for messages to handle. Run on an interval
     // started during the constructor
     Update(): void {
+        this.CheckForHandshakeResponse();
         this.CheckForResponse();
         this.CheckForConfigState();
         this.CheckForServiceStatus();
         this.CheckForTrackingStateResponse();
         this.CheckForAction();
         this.CheckForHandData();
+    }
+
+    // Function: CheckForResponse
+    // Used to check the <responseQueue> for a <WebSocketResponse>. Sends it to Sends it to <HandleCallbackList> with
+    // the <responseCallbacks> dictionary if there is one.
+    CheckForHandshakeResponse(): void {
+        const response: WebSocketResponse | undefined = this.responseQueue.shift();
+
+        if (response !== undefined) {
+            const responseResult = MessageReceiver.HandleCallbackList(response, this.responseCallbacks);
+
+            switch (responseResult) {
+                case 'NoCallbacksFound':
+                    this.LogNoCallbacksWarning(response);
+                    break;
+                case 'Success':
+                    if (response.message && response.status === 'Success') {
+                        if (response.message.indexOf('Handshake Warning') >= 0) {
+                            console.warn('Received Handshake Warning from TouchFree:\n' + response.message);
+                        } else {
+                            console.log('Received Handshake Success from TouchFree:\n' + response.message);
+                        }
+                    } else {
+                        console.error('Received Handshake Error from TouchFree:\n' + response.message);
+                    }
+                    break;
+            }
+        }
+    }
+
+
+    private LogNoCallbacksWarning(response: WebSocketResponse): void {
+        console.warn(
+            'Received a Handshake Response that did not match a callback.' +
+                'This is the content of the response: \n Response ID: ' +
+                response.requestID +
+                '\n Status: ' +
+                response.status +
+                '\n Message: ' +
+                response.message +
+                '\n Original request - ' +
+                response.originalRequest
+        );
     }
 
     // Function: CheckForResponse
@@ -157,17 +210,7 @@ export class MessageReceiver {
 
             switch (responseResult) {
                 case 'NoCallbacksFound':
-                    console.warn(
-                        'Received a WebSocketResponse that did not match a callback.' +
-                            'This is the content of the response: \n Response ID: ' +
-                            response.requestID +
-                            '\n Status: ' +
-                            response.status +
-                            '\n Message: ' +
-                            response.message +
-                            '\n Original request - ' +
-                            response.originalRequest
-                    );
+                    this.LogNoCallbacksWarning(response);
                     break;
                 case 'Success':
                     if (response.message) {
@@ -347,8 +390,10 @@ export class MessageReceiver {
         const lastClearTime: number = Date.now();
 
         MessageReceiver.ClearUnresponsiveItems(lastClearTime, this.responseCallbacks);
+        MessageReceiver.ClearUnresponsiveItems(lastClearTime, this.handshakeCallbacks);
         MessageReceiver.ClearUnresponsiveItems(lastClearTime, this.configStateCallbacks);
         MessageReceiver.ClearUnresponsiveItems(lastClearTime, this.serviceStatusCallbacks);
+        MessageReceiver.ClearUnresponsiveItems(lastClearTime, this.trackingStateCallbacks);
     }
 
     private static ClearUnresponsiveItems<T>(

--- a/TF_Tooling_Web/src/Connection/MessageReceiver.ts
+++ b/TF_Tooling_Web/src/Connection/MessageReceiver.ts
@@ -156,14 +156,14 @@ export class MessageReceiver {
         this.CheckForHandData();
     }
 
-    // Function: CheckForResponse
+    // Function: CheckForHandshakeResponse
     // Used to check the <responseQueue> for a <WebSocketResponse>. Sends it to Sends it to <HandleCallbackList> with
     // the <responseCallbacks> dictionary if there is one.
     CheckForHandshakeResponse(): void {
-        const response: WebSocketResponse | undefined = this.responseQueue.shift();
+        const response: WebSocketResponse | undefined = this.handshakeQueue.shift();
 
         if (response !== undefined) {
-            const responseResult = MessageReceiver.HandleCallbackList(response, this.responseCallbacks);
+            const responseResult = MessageReceiver.HandleCallbackList(response, this.handshakeCallbacks);
 
             switch (responseResult) {
                 case 'NoCallbacksFound':

--- a/TF_Tooling_Web/src/Connection/ServiceConnection.ts
+++ b/TF_Tooling_Web/src/Connection/ServiceConnection.ts
@@ -113,7 +113,7 @@ export class ServiceConnection {
             this.handshakeCompleted = true;
             TouchFree.DispatchEvent('OnConnected');
         } else {
-            console.log(`Connection to Service failed. Details:\n${response.message}`);
+            console.error(`Connection to Service failed. Details:\n${response.message}`);
         }
     };
 
@@ -160,8 +160,13 @@ export class ServiceConnection {
                 break;
             }
 
+            case ActionCode.VERSION_HANDSHAKE_RESPONSE: {
+                const response = looseData.content as WebSocketResponse;
+                ConnectionManager.messageReceiver.handshakeQueue.push(response);
+                break;
+            }
+
             case ActionCode.CONFIGURATION_RESPONSE:
-            case ActionCode.VERSION_HANDSHAKE_RESPONSE:
             case ActionCode.SERVICE_STATUS_RESPONSE:
             case ActionCode.CONFIGURATION_FILE_RESPONSE:
             case ActionCode.QUICK_SETUP_RESPONSE: {

--- a/TF_Tooling_Web/src/Connection/ServiceConnection.ts
+++ b/TF_Tooling_Web/src/Connection/ServiceConnection.ts
@@ -215,8 +215,8 @@ export class ServiceConnection {
         _requestID: string,
         _callback: ((detail: WebSocketResponse | T) => void) | null,
         _callbacksStore: {[id: string]: ResponseCallback}): void => {
-            if (_requestID === '') {
-                if (_callback !== null) {
+            if (!_requestID) {
+                if (_callback) {
                     const response: WebSocketResponse = new WebSocketResponse(
                         '',
                         'Failure',
@@ -230,7 +230,7 @@ export class ServiceConnection {
                 return;
             }
     
-            if (_callback != null) {
+            if (_callback) {
                 _callbacksStore[_requestID] = new ResponseCallback(
                     Date.now(),
                     _callback


### PR DESCRIPTION
## Summary

Improve messages when client and service API versions are different.
Made it so that errors and warnings on handshake return the versions of the client and service to the client.

## Contributor Tasks

_These tasks are for the pull request creator to tick off._

- [ ] Relevant changelogs have been updated with user-visible changes
    - [ ] [TouchFree Windows](/ultraleap/touchfree/blob/-/CHANGELOG-windows.md)
    - [ ] [TouchFree BrightSign](/ultraleap/touchfree/blob/-/CHANGELOG-brightsign.md)
    - [ ] [TouchFree Web Tooling](/ultraleap/touchfree/blob/-/TF_Tooling_Web/CHANGELOG.md)

## Reviewer Tasks

_Add any instructions or tasks for the reviewer such as specific test considerations before this can be merged._

- [ ] Developer testing
- [ ] Code reviewed
- [ ] Non-code assets reviewed
- [ ] Documentation reviewed - includes checking documentation requirements are met and not missing e.g., public API is commented