### PR TITLE
Handle cursor being undefined

### DIFF
--- a/TF_Settings_Web/src/Pages/Visuals/VisualsScreen.tsx
+++ b/TF_Settings_Web/src/Pages/Visuals/VisualsScreen.tsx
@@ -1,7 +1,7 @@
 import styles from './Visuals.module.scss';
 
 import classNames from 'classnames/bind';
-import React, { useState, useEffect, useRef, useMemo } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import tinycolor, { ColorFormats } from 'tinycolor2';
 
 import { readVisualsConfig, isDesktop, writeVisualsConfig } from '@/TauriUtils';
@@ -58,7 +58,7 @@ const VisualsScreen: React.FC = () => {
     const config = useStatefulRef<VisualsConfig>(defaultVisualsConfig);
 
     const [hasReadConfig, setHasReadConfig] = useState<boolean>(false);
-    const [cursor] = useState<SVGCursor>(TouchFree.GetCurrentCursor() as SVGCursor);
+    const [cursor] = useState<SVGCursor | undefined>(TouchFree.GetCurrentCursor() as SVGCursor | undefined);
     const [currentPreviewBgIndex, setCurrentPreviewBgIndex] = useState<number>(0);
 
     useEffect(() => {
@@ -72,8 +72,8 @@ const VisualsScreen: React.FC = () => {
         section.setProperty('--center-border', cursorStyle[2]);
 
         config.current.cursorEnabled
-            ? cursorStyle.forEach((value, index) => cursor.SetColor(index, value))
-            : cursor.ResetToDefaultColors();
+            ? cursorStyle.forEach((value, index) => cursor?.SetColor(index, value))
+            : cursor?.ResetToDefaultColors();
     }, [
         hasReadConfig,
         config.current.cursorEnabled,
@@ -84,14 +84,14 @@ const VisualsScreen: React.FC = () => {
     ]);
 
     const updateConfig = (content: Partial<VisualsConfig>) => {
-        config.current = {...config.current, ...content};
+        config.current = { ...config.current, ...content };
     };
 
     const writeVisualsConfigIfNew = () => {
         if (writtenConfig.current === config.current) return;
         writtenConfig.current = config.current;
         writeVisualsConfig(config.current).catch((err) => console.error(err));
-    }; 
+    };
 
     useEffect(() => {
         readVisualsConfig()
@@ -104,7 +104,7 @@ const VisualsScreen: React.FC = () => {
             .catch((err) => console.error(err));
 
         return () => {
-            cursor.ResetToDefaultColors();
+            cursor?.ResetToDefaultColors();
             window.removeEventListener('pointerup', writeVisualsConfigIfNew);
         };
     }, []);
@@ -237,13 +237,13 @@ const VisualsScreen: React.FC = () => {
                                 leftLabel="1 Seconds"
                                 rightLabel="60 Seconds"
                                 value={roundToTwoDP(config.current.ctiShowAfterTimer)}
-                                onChange={(value) => updateConfig({ ctiShowAfterTimer: value }) }
+                                onChange={(value) => updateConfig({ ctiShowAfterTimer: value })}
                             />
                             <RadioLine
                                 name="Close CTI When"
                                 selected={config.current.ctiHideTrigger}
                                 options={closeCtiOptions}
-                                onChange={(option) => updateConfig({ ctiHideTrigger: closeCtiOptions.indexOf(option)})}
+                                onChange={(option) => updateConfig({ ctiHideTrigger: closeCtiOptions.indexOf(option) })}
                             />
                         </>
                     )}
@@ -257,8 +257,8 @@ const roundToTwoDP = (numberIn: number) => Math.round(numberIn * 100) / 100;
 
 const setCustomColorsFromConfig = (config: VisualsConfig) => {
     const { primaryCustomColor, secondaryCustomColor, tertiaryCustomColor } = config;
-    cursorStyles.Custom = [primaryCustomColor, secondaryCustomColor, tertiaryCustomColor].map(
-        (color) => tinycolor.fromRatio(color).toHex8String()
+    cursorStyles.Custom = [primaryCustomColor, secondaryCustomColor, tertiaryCustomColor].map((color) =>
+        tinycolor.fromRatio(color).toHex8String()
     ) as CursorStyle;
 };
 


### PR DESCRIPTION
## Summary

Fixed bug where the Web Settings would break if:
- you don't have the service running
- opened the Tauri open in dev mode (`npm run tauri dev`)
- went to the Visuals Tab

This was due to assuming the cursor would always be of type SVGCursor which isn't true as it can be undefined if we can't connect to the TF service

Also auto fixed some linting 🤷 

## Contributor Tasks

_These tasks are for the pull request creator to tick off._

- [ ] Relevant changelogs have been updated with user-visible changes

## Reviewer Tasks

_Add any instructions or tasks for the reviewer such as specific test considerations before this can be merged._

- [ ] Developer testing
- [ ] Code reviewed
- [ ] Non-code assets reviewed
- [ ] Documentation reviewed - includes checking documentation requirements are met and not missing e.g., public API is commented