### PR TITLE
[TF-635] - Add unit test for checking plug in order

### DIFF
--- a/TF_Tooling_Web/src/Plugins/tests/InputActionManager.test.ts
+++ b/TF_Tooling_Web/src/Plugins/tests/InputActionManager.test.ts
@@ -4,41 +4,35 @@ import { InputActionManager } from '../InputActionManager';
 import { InputActionPlugin } from '../InputActionPlugin';
 
 describe('InputActionManager', () => {
-    let currentInputAction: TouchFreeInputAction;
-    let currentModifiedAction: TouchFreeInputAction;
-    let pluginCalled = false;
-
-    class MockPlugin extends InputActionPlugin {
-        RunPlugin(inputAction: TouchFreeInputAction): TouchFreeInputAction | null {
-            expect(inputAction).toStrictEqual(currentInputAction);
-            const modifiedInputAction = super.RunPlugin(inputAction);
-            expect(modifiedInputAction).toStrictEqual(currentModifiedAction);
-            pluginCalled = true;
-            return modifiedInputAction;
-        }
-
-        ModifyInputAction(inputAction: TouchFreeInputAction): TouchFreeInputAction | null {
-            currentModifiedAction = { ...inputAction, Timestamp: Date.now() };
-            return currentModifiedAction;
-        }
-
-        TransmitInputAction(inputAction: TouchFreeInputAction): void {
-            expect(inputAction).toStrictEqual(currentModifiedAction);
-        }
-    }
-
-    beforeAll(() => {
-        InputActionManager.SetPlugins([new MockPlugin()]);
-    });
-
     test('Check plugin gets called with the correct data', () => {
-        expect(pluginCalled).toBeFalsy();
+        let currentInputAction: TouchFreeInputAction;
+        let currentModifiedAction: TouchFreeInputAction;
+        let pluginCallCount = 0;
+
+        class MockPlugin extends InputActionPlugin {
+            RunPlugin(inputAction: TouchFreeInputAction): TouchFreeInputAction | null {
+                expect(inputAction).toStrictEqual(currentInputAction);
+                const modifiedInputAction = super.RunPlugin(inputAction);
+                expect(modifiedInputAction).toStrictEqual(currentModifiedAction);
+                pluginCallCount++;
+                return modifiedInputAction;
+            }
+
+            ModifyInputAction(inputAction: TouchFreeInputAction): TouchFreeInputAction | null {
+                currentModifiedAction = { ...inputAction, Timestamp: Date.now() };
+                return currentModifiedAction;
+            }
+
+            TransmitInputAction(inputAction: TouchFreeInputAction): void {
+                expect(inputAction).toStrictEqual(currentModifiedAction);
+            }
+        }
+        InputActionManager.SetPlugins([new MockPlugin()]);
+        expect(pluginCallCount).toBe(0);
         currentInputAction = createInputAction();
         mockTfPluginInputAction(currentInputAction);
-        expect(pluginCalled).toBeTruthy();
-        pluginCalled = false;
+        expect(pluginCallCount).toBe(1);
 
-        expect(pluginCalled).toBeFalsy();
         currentInputAction = new TouchFreeInputAction(
             477777,
             InteractionType.TOUCHPLANE,
@@ -50,6 +44,35 @@ describe('InputActionManager', () => {
             80
         );
         mockTfPluginInputAction(currentInputAction);
-        expect(pluginCalled).toBeTruthy();
+        expect(pluginCallCount).toBe(2);
+    });
+
+    test('Check plugins gets called in the correct order', () => {
+        let pluginCallCount = 0;
+
+        class MockOrderPlugin extends InputActionPlugin {
+            private orderNumber: number;
+
+            constructor(orderNumber: number) {
+                super();
+                this.orderNumber = orderNumber;
+            }
+
+            RunPlugin(inputAction: TouchFreeInputAction): TouchFreeInputAction | null {
+                expect(pluginCallCount).toBe(this.orderNumber);
+                pluginCallCount++;
+                return inputAction;
+            }
+        }
+
+        InputActionManager.SetPlugins([
+            new MockOrderPlugin(0),
+            new MockOrderPlugin(1),
+            new MockOrderPlugin(2),
+            new MockOrderPlugin(3),
+        ]);
+        expect(pluginCallCount).toBe(0);
+        mockTfPluginInputAction();
+        expect(pluginCallCount).toBe(4);
     });
 });

--- a/TF_Tooling_Web/src/Plugins/tests/InputActionManager.test.ts
+++ b/TF_Tooling_Web/src/Plugins/tests/InputActionManager.test.ts
@@ -47,7 +47,7 @@ describe('InputActionManager', () => {
         expect(pluginCallCount).toBe(2);
     });
 
-    test('Check plugins gets called in the correct order', () => {
+    test('Check plugins get called in the correct order', () => {
         let pluginCallCount = 0;
 
         class MockOrderPlugin extends InputActionPlugin {


### PR DESCRIPTION
## Summary

Added a unit test to check that registered plugins are called in the correct order

https://ultrahaptics.atlassian.net/browse/TF-635

### Tests Added

Is a test


## Contributor Tasks

_These tasks are for the pull request creator to tick off._

- [x] Relevant changelogs have been updated with user-visible changes
    - [ ] [TouchFree Windows](/ultraleap/touchfree/blob/-/CHANGELOG-windows.md)
    - [ ] [TouchFree BrightSign](/ultraleap/touchfree/blob/-/CHANGELOG-brightsign.md)
    - [ ] [TouchFree Web Tooling](/ultraleap/touchfree/blob/-/TF_Tooling_Web/CHANGELOG.md)

If there is an associated JIRA issue:
- [x] Include a link to the JIRA issue in the summary above
- [x] Make sure the fix version on the issue is set correctly

## Reviewer Tasks

_Add any instructions or tasks for the reviewer such as specific test considerations before this can be merged._

- [ ] Developer testing
- [ ] Code reviewed
- [ ] Non-code assets reviewed
- [ ] Documentation reviewed - includes checking documentation requirements are met and not missing e.g., public API is commented
