### PR TITLE
[TF-778] Send cancel events from cancelled drag

### DIFF
--- a/TF_Tooling_Web/CHANGELOG.md
+++ b/TF_Tooling_Web/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ability to set the IP and port that tooling should connect to the service via.
 - `SVGCursor.SetColor` allows you to set the color of the SVGCursor center fill, ring fill or center border.
 - `SVGCursor.ResetToDefaultColors` allows you reset the color of the entire SVGCursor back to it's default colors.
+- Cancelled drags (i.e. due to hands lost) now send pointerOut and pointerCancel events to element where the drag started
 
 ### Changed
 

--- a/TF_Tooling_Web/src/InputControllers/WebInputController.ts
+++ b/TF_Tooling_Web/src/InputControllers/WebInputController.ts
@@ -131,6 +131,12 @@ export class WebInputController extends BaseInputController {
                     this.lastHoveredElement.dispatchEvent(outEvent);
                 }
 
+                const elementOnDown = this.GetTopNonCursorElement(this.elementsOnDown);
+                if (elementOnDown) {
+                    elementOnDown.dispatchEvent(cancelEvent);
+                    elementOnDown.dispatchEvent(outEvent);
+                }
+
                 if (elementAtPos !== null) {
                     const parentTree = this.GetOrderedParents(elementAtPos);
 


### PR DESCRIPTION
## Summary

Fixed issue where cancelled drags (i.e. because of handslost) do not send the correct cancel events. 
We now send pointer out and pointer cancel events to the top most element of the down event
https://ultrahaptics.atlassian.net/browse/TF-778

### Tests Added

Updated the tooling-test-app event's page
Updated Zephyr [test](https://ultrahaptics.atlassian.net/projects/TF?selectedItem=com.atlassian.plugins.atlassian-connect-plugin:com.kanoah.test-manager__main-project-page#!/testCase/TF-T36)

## Contributor Tasks

_These tasks are for the pull request creator to tick off._

- [x] Ensure documentation requirements are met e.g., public API is commented
- [x] Relevant changelogs have been updated with user-visible changes
    - [ ] [TouchFree Windows](/ultraleap/touchfree/blob/-/CHANGELOG-windows.md)
    - [ ] [TouchFree BrightSign](/ultraleap/touchfree/blob/-/CHANGELOG-brightsign.md)
    - [x] [TouchFree Web Tooling](/ultraleap/touchfree/blob/-/TF_Tooling_Web/CHANGELOG.md)

If there is an associated JIRA issue:
- [x] Include a link to the JIRA issue in the summary above
- [x] Make sure the fix version on the issue is set correctly

## Reviewer Tasks

_Add any instructions or tasks for the reviewer such as specific test considerations before this can be merged._

- [ ] Developer testing
- [ ] Code reviewed
- [ ] Non-code assets reviewed
- [ ] Documentation reviewed - includes checking documentation requirements are met and not missing e.g., public API is commented
