### PR TITLE
Add service controls to tray application

### DIFF
--- a/CHANGELOG-windows.md
+++ b/CHANGELOG-windows.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Service: `HandEntered` & `HandExited` events, sent when the active hand enters and exits the interaction zone (if enabled) respectively
 - Service: Removed informational level logging to improve readability of log files
 - Unity Settings: Added preset options for dark/light outline cursor
+- Tray app: Added start/stop service controls
 
 ### Changed
 - Unity Settings: Allow resizing of window when in windowed mode

--- a/TF_Service_Utilities/ServiceUITray/ServiceUITray/Program.cs
+++ b/TF_Service_Utilities/ServiceUITray/ServiceUITray/Program.cs
@@ -57,6 +57,9 @@ namespace ServiceUITray
                 ContextMenu = new ContextMenu(new MenuItem[] {
                     touchFreeMenuItem,
                     new MenuItem("-"),
+                    new MenuItem("Start Service", StartService),
+                    new MenuItem("Stop Service", StopService),
+                    new MenuItem("-"),
                     new MenuItem("Settings", Settings),
                 }),
                 Visible = true
@@ -70,6 +73,18 @@ namespace ServiceUITray
             statusCheckTimer.Elapsed += CheckForTouchFree;
             statusCheckTimer.Elapsed += CheckForServiceActivity;
             statusCheckTimer.Start();
+        }
+
+        private void StartService(object sender, EventArgs e)
+        {
+            if (touchFreeService == null) return;
+            touchFreeService.Start();
+        }
+
+        private void StopService(object sender, EventArgs e)
+        {
+            if (touchFreeService == null) return;
+            touchFreeService.Stop();
         }
 
         private void LaunchApp(object sender, EventArgs e)


### PR DESCRIPTION
## Summary

Starting and stopping the service is something that happens regularly during development. This PR gives options to do so from the tray icon rather than having to go through the Windows services application.


### Tests Added

No tests added.


## Contributor Tasks

_These tasks are for the pull request creator to tick off._

- [ ] PO review (optional depending on work type)
- [ ] ~XDR review (optional depending on work type)~
- [ ] QA review (or another developer if no QA is available)
- [ ] ~Ensure documentation requirements are met e.g., public API is commented~
- [x] Relevant changelogs have been updated with user-visible changes
    - [x] [TouchFree Windows](/ultraleap/touchfree/blob/-/CHANGELOG-windows.md)
    - [ ] ~[TouchFree BrightSign](/ultraleap/touchfree/blob/-/CHANGELOG-brightsign.md)~
    - [ ] ~[TouchFree Web Tooling](/ultraleap/touchfree/blob/-/TF_Tooling_Web/CHANGELOG.md)~
- [x] Consider any licensing/other legal implications e.g., notices required

If there is an associated JIRA issue:
- [ ] ~Include a link to the JIRA issue in the summary above~
- [ ] ~Make sure the fix version on the issue is set correctly~

## Reviewer Tasks

_Add any instructions or tasks for the reviewer such as specific test considerations before this can be merged._

- [ ] Developer testing
- [ ] Code reviewed
- [ ] Non-code assets reviewed
- [ ] Documentation reviewed - includes checking documentation requirements are met and not missing e.g., public API is commented
