### PR TITLE
Prevent sending any messages to Clients before a successful handshake

### DIFF
--- a/CHANGELOG-brightsign.md
+++ b/CHANGELOG-brightsign.md
@@ -37,6 +37,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+### Fixed
+- Service: will no longer send some classes of message before a successful handshake from a connecting client
 - Service: Fixed an issue where the TouchFree Service would frequently throw exceptions when a client disconnects
 - Service: Fixed an issue where the TouchFree Service would crash when non-integer configuration value was sent for an integer configuration property e.g. screen width.
 - Service: Fixed several issues which could cause crashes or functionality freezes requiring a restart when dealing with Tracking configuration (masking, camera orientation, etc).

--- a/CHANGELOG-windows.md
+++ b/CHANGELOG-windows.md
@@ -24,6 +24,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Service will no longer send some classes of message before a successful handshake from a connecting client
+
 ## [2.6.0] - 2022-03-20
 
 ### Added

--- a/TF_Service_dotNet/TouchFree/Connections/ClientConnection.cs
+++ b/TF_Service_dotNet/TouchFree/Connections/ClientConnection.cs
@@ -79,7 +79,20 @@ public class ClientConnection : IClientConnection
 
     public void SendInteractionZoneEvent(in InteractionZoneEvent interactionZoneEvent) => SendResponse(interactionZoneEvent, ActionCode.INTERACTION_ZONE_EVENT);
 
-    private void SendHandshakeResponse(in HandShakeResponse response) => SendResponse(response, ActionCode.VERSION_HANDSHAKE_RESPONSE);
+    private void SendHandshakeResponse(in HandShakeResponse response)
+    {
+        var message = new CommunicationWrapper<HandShakeResponse>(
+            ActionCode.VERSION_HANDSHAKE_RESPONSE.ToString(),
+            response);
+
+        string jsonMessage = JsonConvert.SerializeObject(message);
+
+        Socket.SendAsync(
+            Encoding.UTF8.GetBytes(jsonMessage),
+            WebSocketMessageType.Text,
+            true,
+            CancellationToken.None);
+    }
 
     public void SendResponse<T>(in T response, in ActionCode actionCode)
     {

--- a/TF_Service_dotNet/TouchFree/Connections/ClientConnection.cs
+++ b/TF_Service_dotNet/TouchFree/Connections/ClientConnection.cs
@@ -32,19 +32,7 @@ public class ClientConnection : IClientConnection
         TouchFreeLog.WriteLine("Websocket Connection opened");
     }
 
-    public void SendInputAction(in InputAction inputAction)
-    {
-        if (!_handshakeCompleted)
-        {
-            // Long-term we shouldn't get this far until post-handshake, but the systems should
-            // be designed cohesively when the Service gets its polish
-            return;
-        }
-
-        WebsocketInputAction converted = (WebsocketInputAction)inputAction;
-
-        SendResponse(converted, ActionCode.INPUT_ACTION);
-    }
+    public void SendInputAction(in InputAction inputAction) => SendResponse(inputAction, ActionCode.INPUT_ACTION);
 
     public void SendHandData(in HandFrame handFrame, in ArraySegment<byte> lastHandData)
     {

--- a/TF_Service_dotNet/TouchFree/Connections/ClientConnection.cs
+++ b/TF_Service_dotNet/TouchFree/Connections/ClientConnection.cs
@@ -32,7 +32,7 @@ public class ClientConnection : IClientConnection
         TouchFreeLog.WriteLine("Websocket Connection opened");
     }
 
-    public void SendInputAction(in InputAction inputAction) => SendResponse(inputAction, ActionCode.INPUT_ACTION);
+    public void SendInputAction(in InputAction inputAction) => SendResponse((WebsocketInputAction)inputAction, ActionCode.INPUT_ACTION);
 
     public void SendHandData(in HandFrame handFrame, in ArraySegment<byte> lastHandData)
     {

--- a/TF_Service_dotNet/TouchFree/Connections/ClientConnection.cs
+++ b/TF_Service_dotNet/TouchFree/Connections/ClientConnection.cs
@@ -56,7 +56,7 @@ public class ClientConnection : IClientConnection
         }
 
         // TODO: Reduce allocations in this method
-        
+
         string jsonMessage = JsonConvert.SerializeObject(handFrame);
 
         byte[] jsonAsBytes = Encoding.UTF8.GetBytes(jsonMessage);
@@ -83,6 +83,11 @@ public class ClientConnection : IClientConnection
 
     public void SendResponse<T>(in T response, in ActionCode actionCode)
     {
+        if (!_handshakeCompleted)
+        {
+            return;
+        }
+
         var message = new CommunicationWrapper<T>(actionCode.ToString(), response);
 
         string jsonMessage = JsonConvert.SerializeObject(message);
@@ -99,7 +104,7 @@ public class ClientConnection : IClientConnection
     public static CompatibilityInformation GetVersionCompability(string clientVersion, Version coreVersion)
     {
         Version clientVersionParsed = new Version(clientVersion);
-        
+
         Compatibility compatibility;
         if (clientVersionParsed.Major < coreVersion.Major) compatibility = Compatibility.CLIENT_OUTDATED;
         else if (clientVersionParsed.Major > coreVersion.Major) compatibility = Compatibility.SERVICE_OUTDATED;


### PR DESCRIPTION
## Summary

Corrects a minor issue where _some_ messages were leaked to a connected client that had not yet completed the handshake.

Closes [TF-1280](https://ultrahaptics.atlassian.net/browse/TF-1280)

### Tests Added

I wouldn't recommend that this has a recurring test in our test plan as it's not a major issue.

To test this manually, use the test script found [here on Box](https://ultrahaptics.box.com/s/ani79xdgijco53a7mj6h431oe59h798s), which includes instructions on its use.

## Contributor Tasks

_These tasks are for the pull request creator to tick off._

- [ ] PO review (optional depending on work type)
- [ ] XDR review (optional depending on work type)
- [ ] QA review (or another developer if no QA is available)
- [ ] Ensure documentation requirements are met e.g., public API is commented
- [x] Relevant changelogs have been updated with user-visible changes
    - [x] [TouchFree Windows](/ultraleap/touchfree/blob/-/CHANGELOG-windows.md)
    - [ ] [TouchFree BrightSign](/ultraleap/touchfree/blob/-/CHANGELOG-brightsign.md)
    - [ ] [TouchFree Web Tooling](/ultraleap/touchfree/blob/-/TF_Tooling_Web/CHANGELOG.md)
- [ ] Consider any licensing/other legal implications e.g., notices required

If there is an associated JIRA issue:
- [x] Include a link to the JIRA issue in the summary above
- [x] Make sure the fix version on the issue is set correctly

## Reviewer Tasks

_Add any instructions or tasks for the reviewer such as specific test considerations before this can be merged._

- [x] Developer testing
- [x] Code reviewed
- [ ] Non-code assets reviewed
- [ ] Documentation reviewed - includes checking documentation requirements are met and not missing e.g., public API is commented


[TF-1280]: https://ultrahaptics.atlassian.net/browse/TF-1280?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ