### PR TITLE
Add `SetCurrentCursor` to base TouchFree object

### DIFF
--- a/TF_Tooling_Web/CHANGELOG.md
+++ b/TF_Tooling_Web/CHANGELOG.md
@@ -13,6 +13,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `TouchFree.SetCurrentCursor` allows you to set the current cursor of TouchFree. For use when `initialiseCursor` is set to `false`.
+
+## [1.4.0] - 2023-04-06
+
+### Added
+
 - `ServiceStatus` now includes the service version, tracking version, camera serial number and camera firmware version.
 - `OnServiceStatusChange` event - provides data about the status of the TouchFree Service whenever it changes.
 - `WhenConnected` event - functions identically to `OnConnected` but will dispatch an event immediately if already connected to the TouchFree Service.

--- a/TF_Tooling_Web/src/TouchFree.ts
+++ b/TF_Tooling_Web/src/TouchFree.ts
@@ -17,6 +17,7 @@ export interface TfInitParams {
 }
 
 const GetCurrentCursor = () => CurrentCursor;
+const SetCurrentCursor = (cursor: TouchlessCursor) => (CurrentCursor = cursor);
 const GetInputController = () => InputController;
 
 // Function: Init
@@ -254,6 +255,7 @@ const DispatchEvent = <TEvent extends TouchFreeEvent>(
 export default {
     CurrentCursor,
     GetCurrentCursor,
+    SetCurrentCursor,
     DispatchEvent,
     Init,
     InputController,

--- a/TF_Tooling_Web/src/tests/TouchFree.test.ts
+++ b/TF_Tooling_Web/src/tests/TouchFree.test.ts
@@ -1,4 +1,5 @@
 import { ConnectionManager } from '../Connection/ConnectionManager';
+import { SVGCursor } from '../Cursors/SvgCursor';
 import TouchFree from '../TouchFree';
 import { TouchFreeEventSignatures, TouchFreeEvent } from '../TouchFreeToolingTypes';
 
@@ -26,15 +27,15 @@ describe('TouchFree', () => {
                 TouchFree.DispatchEvent('OnConnected');
                 expect(fn).toBeCalled();
             });
-            return;
+        } else {
+            it(`Should trigger appropriate callbacks when ${key} event is dispatched`, () => {
+                TouchFree.Init();
+                const newKey = key as TouchFreeEvent;
+                TouchFree.RegisterEventCallback(newKey, fn);
+                TouchFree.DispatchEvent(newKey);
+                expect(fn).toBeCalled();
+            });
         }
-        it(`Should trigger appropriate callbacks when ${key} event is dispatched`, () => {
-            TouchFree.Init();
-            const newKey = key as TouchFreeEvent;
-            TouchFree.RegisterEventCallback(newKey, fn);
-            TouchFree.DispatchEvent(newKey);
-            expect(fn).toBeCalled();
-        });
     }
 
     it('Should pass a given address to the ConnectionManager', () => {
@@ -42,5 +43,12 @@ describe('TouchFree', () => {
         TouchFree.Init({ address: newAddress });
         expect(ConnectionManager.iPAddress).toBe(newAddress.ip);
         expect(ConnectionManager.port).toBe(newAddress.port);
+    });
+
+    it('Should set the cursor correctly', () => {
+        const cursor = new SVGCursor();
+        cursor.DisableCursor();
+        TouchFree.SetCurrentCursor(cursor);
+        expect(TouchFree.GetCurrentCursor()).toBe(cursor);
     });
 });

--- a/TF_Tooling_Web/src/tests/TouchFree.test.ts
+++ b/TF_Tooling_Web/src/tests/TouchFree.test.ts
@@ -1,4 +1,5 @@
 import { ConnectionManager } from '../Connection/ConnectionManager';
+import { DotCursor } from '../Cursors/DotCursor';
 import { SVGCursor } from '../Cursors/SvgCursor';
 import TouchFree from '../TouchFree';
 import { TouchFreeEventSignatures, TouchFreeEvent } from '../TouchFreeToolingTypes';
@@ -50,5 +51,9 @@ describe('TouchFree', () => {
         cursor.DisableCursor();
         TouchFree.SetCurrentCursor(cursor);
         expect(TouchFree.GetCurrentCursor()).toBe(cursor);
+
+        const newCursor = new DotCursor(new Image(), new Image());
+        TouchFree.SetCurrentCursor(newCursor);
+        expect(TouchFree.GetCurrentCursor()).toBe(newCursor);
     });
 });


### PR DESCRIPTION
## Summary

Adds the `SetCurrentCursor` function to the base of Web Tooling to allow users to add custom cursors to the TouchFree object.

## Contributor Tasks

_These tasks are for the pull request creator to tick off._

- [ ] Relevant changelogs have been updated with user-visible changes
    - [ ] [TouchFree Windows](/ultraleap/touchfree/blob/-/CHANGELOG-windows.md)
    - [ ] [TouchFree BrightSign](/ultraleap/touchfree/blob/-/CHANGELOG-brightsign.md)
    - [x] [TouchFree Web Tooling](/ultraleap/touchfree/blob/-/TF_Tooling_Web/CHANGELOG.md)

## Reviewer Tasks

_Add any instructions or tasks for the reviewer such as specific test considerations before this can be merged._

- [ ] Developer testing
- [x] Code reviewed
- [ ] Non-code assets reviewed
- [ ] Documentation reviewed - includes checking documentation requirements are met and not missing e.g., public API is commented